### PR TITLE
update next config to remove the warning

### DIFF
--- a/apps/docs/.eslintrc.json
+++ b/apps/docs/.eslintrc.json
@@ -2,6 +2,12 @@
   "$schema": "https://json.schemastore.org/eslintrc",
   "root": true,
   "extends": [
+    "next",
     "plugin:@workleap/web-application"
-  ]
+  ],
+  "settings": {
+    "next": {
+        "rootDir": "apps/docs"
+    }
+  }
 }


### PR DESCRIPTION

warn  - The Next.js plugin was not detected in your ESLint configuration. See https://nextjs.org/docs/basic-features/eslint#migrating-existing-config

then caused 

`Pages directory cannot be found at . If using a custom path, please configure with the `no-html-link-for-pages` rule in your eslint config file.`

Both are fixed now