### PR TITLE
Adding inline svgs to the svg-icons package

### DIFF
--- a/.changeset/eight-islands-invent.md
+++ b/.changeset/eight-islands-invent.md
@@ -1,0 +1,5 @@
+---
+"@hopper-ui/svg-icons": minor
+---
+
+svg-icons now export the SVG as inline strings. You can import the string containing the SVG from @hopper-ui/svg-icon/inline

--- a/.changeset/tidy-mangos-hug.md
+++ b/.changeset/tidy-mangos-hug.md
@@ -1,0 +1,5 @@
+---
+"@hopper-ui/components": patch
+---
+
+Fixed an issue where locale wasn't properly forwarded in modales and popover

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -11,10 +11,6 @@ on:
         # Opened, synchronize, or reopened are the default types
         # We added ready_for_review to trigger the workflow is passed from draft to ready_for_review
         types: ["opened", "synchronize", "reopened", "ready_for_review"]
-        # Workflows will not run on pull_request activity if the pull request has a merge conflict. The merge conflict must be resolved first.
-        # By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened.
-        branches-ignore:
-            - changeset-release/*
 
 concurrency:
     group: chromatic-${{ github.head_ref || github.ref }}
@@ -67,7 +63,8 @@ jobs:
                     traceChanged: true
                     onlyChanged: true # TurboSnap
                     exitOnceUploaded: true # The PRs will be marked as success/failure based on the Chromatic build status
-                    skip: ${{ github.event.pull_request.draft == true }}
+                    skip: ${{ github.event.pull_request.draft == true || startsWith(github.ref, 'refs/heads/changeset-release/') }}
+
 
             -   name: Write to Github comment
                 uses: thollander/actions-comment-pull-request@v2

--- a/apps/docs/content/components/application/HopperProvider.mdx
+++ b/apps/docs/content/components/application/HopperProvider.mdx
@@ -31,8 +31,7 @@ Hopper currently supports the following locales: `en-US`, `en-UK`, `fr-CA`, `fr-
 
 <CodeOnlyExample src="HopperProvider/docs/hopper-provider/locale" />
 
-{/* TODO, hopper should re-export useLocale and document it? */}
-To access the current locale anywhere in your application, see the [useLocale](https://react-spectrum.adobe.com/react-aria/useLocale.html) hook.
+To access the current locale anywhere in your application, see the `useLocale` hook.
 
 ### Client side routing
 
@@ -73,6 +72,10 @@ body {
 `withCssVariables` determines whether Hopper's CSS variables should be added to your application. By default, it is set to true and should not be changed unless you want to manage CSS variables via a CSS file. Note that in this case, you will need to add the tokens manually, ideally using the `@hopper-ui/tokens` package.
 
 <CodeOnlyExample src="HopperProvider/docs/hopper-provider/inject-css-var" />
+
+### useHopperContext
+
+If you need to access the HopperProvider properties in a component, you can use the `useHopperContext` hook. This hook returns the Hopper context object, which includes the color scheme, locale, and other settings.
 
 ## Props
 

--- a/apps/docs/content/icons/SVG-icons/icon-library.mdx
+++ b/apps/docs/content/icons/SVG-icons/icon-library.mdx
@@ -27,8 +27,13 @@ or in a CSS file:
 
 Hopper's SVG icons are designed to be used as inline SVGs. This allows you to easily customize the icon's color, size, and other properties using CSS.
 ```tsx
-import { Alert32Icon } from "@hopper-ui/svg-icons/icons/inline";
+// a specific size
+import { AlertIcon32 } from "@hopper-ui/svg-icons/icons/inline";
+// or an object containing all the sizes
+import { AlertIcon }  from "@hopper-ui/svg-icons/icons/inline";
 ```
+
+
 
 You can preview icons in your preferred size. Simply click on an icon to instantly copy it's `.svg` name!
 

--- a/apps/docs/content/icons/SVG-icons/icon-library.mdx
+++ b/apps/docs/content/icons/SVG-icons/icon-library.mdx
@@ -33,8 +33,6 @@ import { AlertIcon32 } from "@hopper-ui/svg-icons/icons/inline";
 import { AlertIcon }  from "@hopper-ui/svg-icons/icons/inline";
 ```
 
-
-
 You can preview icons in your preferred size. Simply click on an icon to instantly copy it's `.svg` name!
 
 <Switcher type="svg"/>

--- a/apps/docs/content/icons/SVG-icons/icon-library.mdx
+++ b/apps/docs/content/icons/SVG-icons/icon-library.mdx
@@ -14,15 +14,22 @@ All icons in the Workleap icon library are available in three predefined sizes. 
 To integrate an icon into your project, simply import it from `@hopper-ui/svg-icons` in a JavaScript file:
 
 ```tsx
-import AlertIcon from "@hopper-ui/svg-icons/alert-24.svg";
+import AlertIcon from "@hopper-ui/svg-icons/icons/alert-24.svg";
 ```
 or in a CSS file:
 ```css
 .my-component {
-    background-image: url("@hopper-ui/svg-icons/alert-24.svg");
+    background-image: url("@hopper-ui/svg-icons/icons/alert-24.svg");
 }
 ```
 
-You can preview icons in your preferred size. Simply click on an icon to instantly copy its name!
+## Inline SVG
+
+Hopper's SVG icons are designed to be used as inline SVGs. This allows you to easily customize the icon's color, size, and other properties using CSS.
+```tsx
+import { Alert32Icon } from "@hopper-ui/svg-icons/icons/inline";
+```
+
+You can preview icons in your preferred size. Simply click on an icon to instantly copy it's `.svg` name!
 
 <Switcher type="svg"/>

--- a/apps/docs/content/icons/SVG-icons/rich-icon-library.mdx
+++ b/apps/docs/content/icons/SVG-icons/rich-icon-library.mdx
@@ -14,12 +14,12 @@ All rich icons in the Workleap icon library are available in three predefined si
 To integrate a rich icon into your project, simply import it from `@hopper-ui/svg-icons` in a JavaScript file:
 
 ```tsx
-import ActionListRichIcon from "@hopper-ui/svg-icons/action-list-32.svg";
+import ActionListRichIcon from "@hopper-ui/svg-icons/rich-icons/action-list-32.svg";
 ```
 or in a CSS file:
 ```css
 .my-component {
-    background-image: url("@hopper-ui/svg-icons/action-list-32.svg");
+    background-image: url("@hopper-ui/svg-icons/rich-icons/action-list-32.svg");
 }
 ```
 

--- a/packages/components/src/HopperProvider/src/HopperProvider.tsx
+++ b/packages/components/src/HopperProvider/src/HopperProvider.tsx
@@ -54,6 +54,20 @@ export const HopperContext = createContext<HopperProviderProps | null>(null);
 
 /**
  * This hook is used to get the HopperProviderProps from the nearest HopperProvider ancestor.
+ */
+export function useHopperContext() {
+    const context = useContext(HopperContext);
+
+    if (context === null) {
+        throw new Error("useHopperContext must be used within a HopperProvider");
+    }
+
+    return context;
+}
+
+
+/**
+ * This hook is used to get the HopperProviderProps from the nearest HopperProvider ancestor.
  * It will only return the props that would need to be forwarded to the next HopperProvider.
  */
 export function useForwardedHopperContext() {

--- a/packages/components/src/Modal/src/BaseModal.tsx
+++ b/packages/components/src/Modal/src/BaseModal.tsx
@@ -3,7 +3,7 @@ import clsx from "clsx";
 import { type CSSProperties, type ForwardedRef, forwardRef } from "react";
 import { ModalOverlay, type ModalOverlayProps, type ModalRenderProps, Modal as RACModal, useContextProps } from "react-aria-components";
 
-import { HopperProvider } from "../../HopperProvider/index.ts";
+import { HopperProvider, useForwardedHopperContext } from "../../HopperProvider/index.ts";
 import { cssModule } from "../../utils/index.ts";
 
 import { BaseModalContext } from "./BaseModalContext.ts";
@@ -39,7 +39,7 @@ const BaseModal = (props: BaseModalProps, ref: ForwardedRef<HTMLDivElement>) => 
 
     const { colorScheme } = useColorSchemeContext();
     const size = useResponsiveValue(sizeProp) ?? "md";
-
+    const prevContextProps = useForwardedHopperContext();
     const classNames = (renderProps: ModalRenderProps) => clsx(
         GlobalBaseModalCssSelector,
         cssModule(
@@ -66,7 +66,7 @@ const BaseModal = (props: BaseModalProps, ref: ForwardedRef<HTMLDivElement>) => 
             slot={slot}
             {...otherProps}
         >
-            <HopperProvider colorScheme={colorScheme} withCssVariables={false}>
+            <HopperProvider {...prevContextProps}>
                 <RACModal {...otherProps} ref={ref} className={styles["hop-BaseModal__modal"]}>
                     {children}
                 </RACModal>

--- a/packages/components/src/Modal/src/BaseModal.tsx
+++ b/packages/components/src/Modal/src/BaseModal.tsx
@@ -1,4 +1,4 @@
-import { type ResponsiveProp, type StyledComponentProps, useColorSchemeContext, useResponsiveValue, useStyledSystem } from "@hopper-ui/styled-system";
+import { type ResponsiveProp, type StyledComponentProps, useResponsiveValue, useStyledSystem } from "@hopper-ui/styled-system";
 import clsx from "clsx";
 import { type CSSProperties, type ForwardedRef, forwardRef } from "react";
 import { ModalOverlay, type ModalOverlayProps, type ModalRenderProps, Modal as RACModal, useContextProps } from "react-aria-components";
@@ -37,7 +37,6 @@ const BaseModal = (props: BaseModalProps, ref: ForwardedRef<HTMLDivElement>) => 
         ...otherProps
     } = ownProps;
 
-    const { colorScheme } = useColorSchemeContext();
     const size = useResponsiveValue(sizeProp) ?? "md";
     const prevContextProps = useForwardedHopperContext();
     const classNames = (renderProps: ModalRenderProps) => clsx(

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -39,8 +39,20 @@ export * from "@hopper-ui/styled-system";
 export { filterDOMProps, useId } from "@react-aria/utils";
 export { useAsyncList } from "@react-stately/data";
 export type { RouterOptions } from "@react-types/shared";
-export { useFilter } from "react-aria";
+export {
+    useFilter
+} from "react-aria";
 export type { Orientation, Placement } from "react-aria";
-export { Collection, DEFAULT_SLOT, useContextProps, useSlottedContext, type ContextValue, type Key, type Selection, type ValidationResult } from "react-aria-components";
+export {
+    Collection,
+    DEFAULT_SLOT,
+    useContextProps,
+    useLocale,
+    useSlottedContext,
+    type ContextValue,
+    type Key,
+    type Selection,
+    type ValidationResult
+} from "react-aria-components";
 
 import "./index.css";

--- a/packages/components/src/overlays/Popover/src/Popover.tsx
+++ b/packages/components/src/overlays/Popover/src/Popover.tsx
@@ -1,4 +1,4 @@
-import { useColorSchemeContext, useResponsiveValue, useStyledSystem, type ResponsiveProp, type StyledComponentProps, type StyledSystemProps } from "@hopper-ui/styled-system";
+import { useResponsiveValue, useStyledSystem, type ResponsiveProp, type StyledComponentProps, type StyledSystemProps } from "@hopper-ui/styled-system";
 import clsx from "clsx";
 import { forwardRef, type ForwardedRef } from "react";
 import type { Placement } from "react-aria";
@@ -11,7 +11,7 @@ import {
 } from "react-aria-components";
 
 import { ButtonContext, ButtonGroupContext, LinkButtonContext } from "../../../buttons/index.ts";
-import { HopperProvider } from "../../../HopperProvider/index.ts";
+import { HopperProvider, useForwardedHopperContext } from "../../../HopperProvider/index.ts";
 import { ContentContext, FooterContext } from "../../../layout/index.ts";
 import { LinkContext } from "../../../Link/index.ts";
 import { ListBoxContext } from "../../../ListBox/index.ts";
@@ -52,6 +52,7 @@ export interface PopoverProps extends StyledComponentProps<Omit<RACPopoverProps,
 function Popover(props: PopoverProps, ref: ForwardedRef<HTMLElement>) {
     [props, ref] = useContextProps(props, ref, PopoverContext);
     const { stylingProps, ...ownProps } = useStyledSystem(props);
+    const prevContextProps = useForwardedHopperContext();
     const {
         isAutoWidth,
         children,
@@ -74,8 +75,6 @@ function Popover(props: PopoverProps, ref: ForwardedRef<HTMLElement>) {
         slot,
         ...containerOtherProps
     } = containerOwnProps;
-
-    const { colorScheme } = useColorSchemeContext();
 
     const popoverClassNames = composeClassnameRenderProps(
         className,
@@ -122,7 +121,7 @@ function Popover(props: PopoverProps, ref: ForwardedRef<HTMLElement>) {
 
                 if (isNonDialog) {
                     return (
-                        <HopperProvider colorScheme={colorScheme} className={styles["hop-Popover__wrapper"]}>
+                        <HopperProvider {...prevContextProps} className={styles["hop-Popover__wrapper"]}>
                             <div
                                 {...containerOtherProps}
                                 className={containerClassNames}
@@ -151,7 +150,7 @@ function Popover(props: PopoverProps, ref: ForwardedRef<HTMLElement>) {
                 }
 
                 return (
-                    <HopperProvider colorScheme={colorScheme}>
+                    <HopperProvider {...prevContextProps}>
                         <Dialog {...containerOtherProps} className={containerClassNames} style={containerStyle}>
                             <SlotProvider values={[
                                 [HeadingContext, {

--- a/packages/svg-icons/package.json
+++ b/packages/svg-icons/package.json
@@ -14,7 +14,7 @@
         "provenance": true
     },
     "type": "module",
-    "sideEffects": "*.svg",
+    "sideEffects": false,
     "files": [
         "/dist",
         "CHANGELOG.md",
@@ -22,13 +22,15 @@
     ],
     "exports": {
         "./icons/*.svg": "./dist/icons/*.svg",
+        "./icons/inline/*": "./dist/icons/inline/*",
         "./rich-icons/*.svg": "./dist/rich-icons/*.svg"
     },
     "scripts": {
         "build": "pnpm run \"/^build:.*/\"",
         "build:icons": "copyfiles --flat src/optimized-icons/* dist/icons",
+        "build:inline-icons": "tsx scripts/buildInlineIcons.ts",
         "build:rich-icons": "copyfiles --flat src/optimized-rich-icons/* dist/rich-icons",
-        "generate-icons": "tsx scripts/build.ts",
+        "generate-icons": "tsx scripts/generate.ts",
         "eslint": "eslint . --max-warnings=0 --cache --cache-location node_modules/.cache/eslint",
         "typecheck": "tsc",
         "test": "jest"

--- a/packages/svg-icons/package.json
+++ b/packages/svg-icons/package.json
@@ -22,7 +22,11 @@
     ],
     "exports": {
         "./icons/*.svg": "./dist/icons/*.svg",
-        "./icons/inline/*": "./dist/icons/inline/*",
+        "./icons/inline": {
+            "types": "./dist/icons/inline/index.d.ts",
+            "import": "./dist/icons/inline/index.js",
+            "default": "./dist/icons/inline/index.js"
+        },
         "./rich-icons/*.svg": "./dist/rich-icons/*.svg"
     },
     "scripts": {

--- a/packages/svg-icons/scripts/buildInlineIcons.ts
+++ b/packages/svg-icons/scripts/buildInlineIcons.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 
-import { IconsInlineDistDirectory, IconsOptimizedDirectory } from "./constants.ts";
+import { IconsInlineDistDirectory, IconSizes, IconsOptimizedDirectory } from "./constants.ts";
 
 const optimizedIconsPath = IconsOptimizedDirectory;
 
@@ -10,9 +10,15 @@ const optimizedIconsPath = IconsOptimizedDirectory;
  * @example fileNameConverter("C:\Dev\wl-hopper\packages\svg-icons\src\optimized-rich-icons\action-list-24.svg") // ActionListIcon24
  */
 function fileNameConverter(filePath: string) {
-    const fileName = path.basename(filePath, ".svg");
+    let fileName = path.basename(filePath, ".svg");
 
-    return fileName.split("-").map(s => s.charAt(0).toUpperCase() + s.slice(1)).join("") + "Icon";
+    fileName = fileName.split("-").map(s => s.charAt(0).toUpperCase() + s.slice(1)).join("");
+
+    IconSizes.forEach(size => {
+        fileName = fileName.replace(size.toString(), `Icon${size}`);
+    });
+
+    return fileName;
 }
 
 const files = fs.readdirSync(optimizedIconsPath, { recursive: true, withFileTypes: true });

--- a/packages/svg-icons/scripts/buildInlineIcons.ts
+++ b/packages/svg-icons/scripts/buildInlineIcons.ts
@@ -1,0 +1,25 @@
+import fs from "fs";
+import path from "path";
+
+import { IconsInlineDistDirectory, IconsOptimizedDirectory } from "./constants.ts";
+
+//
+const optimizedIconsPath = IconsOptimizedDirectory;
+
+console.log("⚙️  Generating inline icons...\n");
+
+const files = fs.readdirSync(optimizedIconsPath, { recursive: true, withFileTypes: true });
+const svgFiles = files.filter(file => file.isFile() && file.name.endsWith(".svg"));
+
+// Clear directory (It also removes the directory itself)
+fs.rmSync(IconsInlineDistDirectory, { recursive: true, force: true });
+fs.mkdirSync(IconsInlineDistDirectory, { recursive: true });
+
+svgFiles.forEach(file => {
+    const contents = fs.readFileSync(path.resolve(file.path, file.name), "utf8");
+    // TODO: fix the /, there is probably a method to join those paths
+    fs.writeFileSync(`${IconsInlineDistDirectory}/${file.name.replace(".svg", ".js")}`, `export default \`${contents}\``);
+    fs.writeFileSync(`${IconsInlineDistDirectory}/${file.name.replace(".svg", ".d.ts")}`, "declare const _default: string; export default _default;");
+});
+
+console.log("✨ The inline icons have been generated!\n");

--- a/packages/svg-icons/scripts/buildInlineIcons.ts
+++ b/packages/svg-icons/scripts/buildInlineIcons.ts
@@ -3,10 +3,17 @@ import path from "path";
 
 import { IconsInlineDistDirectory, IconsOptimizedDirectory } from "./constants.ts";
 
-//
 const optimizedIconsPath = IconsOptimizedDirectory;
 
-console.log("⚙️  Generating inline icons...\n");
+/**
+ * Converts a file path to a file name.
+ * @example fileNameConverter("C:\Dev\wl-hopper\packages\svg-icons\src\optimized-rich-icons\action-list-24.svg") // ActionListIcon24
+ */
+function fileNameConverter(filePath: string) {
+    const fileName = path.basename(filePath, ".svg");
+
+    return fileName.split("-").map(s => s.charAt(0).toUpperCase() + s.slice(1)).join("") + "Icon";
+}
 
 const files = fs.readdirSync(optimizedIconsPath, { recursive: true, withFileTypes: true });
 const svgFiles = files.filter(file => file.isFile() && file.name.endsWith(".svg"));
@@ -15,11 +22,32 @@ const svgFiles = files.filter(file => file.isFile() && file.name.endsWith(".svg"
 fs.rmSync(IconsInlineDistDirectory, { recursive: true, force: true });
 fs.mkdirSync(IconsInlineDistDirectory, { recursive: true });
 
-svgFiles.forEach(file => {
+const inlinedSvgs = svgFiles.map(file => {
     const contents = fs.readFileSync(path.resolve(file.path, file.name), "utf8");
-    // TODO: fix the /, there is probably a method to join those paths
-    fs.writeFileSync(`${IconsInlineDistDirectory}/${file.name.replace(".svg", ".js")}`, `export default \`${contents}\``);
-    fs.writeFileSync(`${IconsInlineDistDirectory}/${file.name.replace(".svg", ".d.ts")}`, "declare const _default: string; export default _default;");
+    const name = fileNameConverter(file.name);
+    const fileName = `${name}.js`;
+    const location = path.resolve(IconsInlineDistDirectory, fileName);
+    fs.writeFileSync(location, `export default \`${contents}\``);
+
+    return {
+        name,
+        fileName,
+        location
+    };
 });
+
+// index barrel file
+fs.writeFileSync(path.resolve(IconsInlineDistDirectory, "index.js"), inlinedSvgs.map(file => {
+    const name = file.name;
+
+    return `export { default as ${name} } from "./${file.fileName}";\n`;
+}).join(""));
+
+// types barrel file
+fs.writeFileSync(path.resolve(IconsInlineDistDirectory, "index.d.ts"), inlinedSvgs.map(file => {
+    const name = file.name;
+
+    return `export const ${name}: string;\n`;
+}).join(""));
 
 console.log("✨ The inline icons have been generated!\n");

--- a/packages/svg-icons/scripts/constants.ts
+++ b/packages/svg-icons/scripts/constants.ts
@@ -9,11 +9,12 @@ export const WhiteHexadecimal = "#fff";
 export const White = "white"; // TODO: should be --hop-decorative-option7-icon-strong
 
 export const IconsSourceDirectory = "src/icons";
-export const IconsDistDirectory = "src/optimized-icons";
+export const IconsInlineDistDirectory = "dist/icons/inline";
+export const IconsOptimizedDirectory = "src/optimized-icons";
 export const IconSizes = [16, 24, 32] as const;
 export const AllowedIconFillColors = [NeutralIconColor, PrimaryIconColor, WarningWeakIconColor];
 
 export const RichIconsSourceDirectory = "src/rich-icons";
-export const RichIconsDistDirectory = "src/optimized-rich-icons";
+export const RichIconsOptimizedDirectory = "src/optimized-rich-icons";
 export const RichIconSizes = [24, 32, 40] as const;
 export const RichAllowedIconFillColors = [DecorativeOption7IconColor, DecorativeOption7SurfaceColor, White];

--- a/packages/svg-icons/scripts/generate.ts
+++ b/packages/svg-icons/scripts/generate.ts
@@ -1,7 +1,7 @@
 import path from "path";
 
-import { IconSizes, IconsDistDirectory, IconsSourceDirectory, RichIconSizes, RichIconsDistDirectory, RichIconsSourceDirectory } from "./constants.ts";
-import { generateIcons } from "./generateIcons.ts";
+import { IconSizes, IconsOptimizedDirectory, IconsSourceDirectory, RichIconSizes, RichIconsOptimizedDirectory, RichIconsSourceDirectory } from "./constants.ts";
+import { optimizeIcon } from "./optimize.ts";
 
 /**
  * Converts a file path to a file name.
@@ -27,10 +27,10 @@ function fileNameConverter(filePath: string, allowedIconSizes: readonly number[]
 
 console.log("⚙️  Optimizing icons...\n");
 
-generateIcons(IconsSourceDirectory, IconsDistDirectory, filePath => fileNameConverter(filePath, IconSizes));
+optimizeIcon(IconsSourceDirectory, IconsOptimizedDirectory, filePath => fileNameConverter(filePath, IconSizes));
 
 console.log("⚙️  Optimizing rich icons...\n");
 
-generateIcons(RichIconsSourceDirectory, RichIconsDistDirectory, filePath => fileNameConverter(filePath, RichIconSizes));
+optimizeIcon(RichIconsSourceDirectory, RichIconsOptimizedDirectory, filePath => fileNameConverter(filePath, RichIconSizes));
 
 console.log("✨ The icons have been optimized!\n");

--- a/packages/svg-icons/scripts/optimize.ts
+++ b/packages/svg-icons/scripts/optimize.ts
@@ -4,7 +4,7 @@ import { optimize } from "svgo";
 
 import config from "./svgoConfig.ts";
 
-export function generateIcons(srcDir: string, outputDir: string, fileNameConverter?: (filePath: string) => string) {
+export function optimizeIcon(srcDir: string, outputDir: string, fileNameConverter?: (filePath: string) => string) {
     // Clear directory (It also removes the directory itself)
     fs.rmSync(outputDir, { recursive: true, force: true });
     fs.mkdirSync(outputDir, { recursive: true });

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,8 @@
     "tasks": {
         "build": {
             "dependsOn": ["^build"],
-            "outputs": ["dist/**", ".next/**", "**/datas/**"]
+            "outputs": ["dist/**", ".next/**", "**/datas/**"],
+            "cache": false
         },
         "lint": {
             "dependsOn": ["eslint", "typecheck", "stylelint"]


### PR DESCRIPTION
Here are the different steps of the svg-icons project:

**Add the SVG**
Place the SVG provided by design into the svg-icons/src folder.

**Generate optimized icons**
Run the generate-icons command. This process:
- Optimizes the SVG.
- Moves it to the src/optimized-icons folder.
- Replaces hardcoded colors with CSS variables, allowing customization.

**Build step**
Previously, there was no build step, only a copy from src/optimized-icons to dist/.
Now, an additional step has been introduced:
  - The build reads files from src/optimized-icons/.
  - It generates a .js file in dist/icons/inline/, exporting the inlined SVG as a string.
  - It generated a index.js and index.d.ts file to export all the inline svgs
