### PR TITLE
fix: Image's alt was logging an warning that was a false positive, and PopoverBase now forwards the zIndex

### DIFF
--- a/.changeset/great-singers-kneel.md
+++ b/.changeset/great-singers-kneel.md
@@ -1,0 +1,5 @@
+---
+"@hopper-ui/components": patch
+---
+
+Fixed an issue where the Image component was logging a warning when the `alt` prop was provided, but empty.

--- a/.changeset/stupid-cameras-impress.md
+++ b/.changeset/stupid-cameras-impress.md
@@ -1,0 +1,5 @@
+---
+"@hopper-ui/components": patch
+---
+
+Fixed an issue where the zIndex should of been forwarded

--- a/packages/components/src/Image/src/Image.tsx
+++ b/packages/components/src/Image/src/Image.tsx
@@ -40,7 +40,7 @@ function Image(props: ImageProps, ref: ForwardedRef<HTMLImageElement>) {
         ...otherProps
     } = ownProps;
 
-    if (!alt) {
+    if (alt === undefined) {
         console.warn(
             "The `alt` prop was not provided to an image. " +
             "Add `alt` text for screen readers, or set `alt=\"\"` prop to indicate that the image " +

--- a/packages/components/src/overlays/Popover/src/PopoverBase.tsx
+++ b/packages/components/src/overlays/Popover/src/PopoverBase.tsx
@@ -63,10 +63,7 @@ function PopoverBase(props: PopoverBaseProps, ref: ForwardedRef<HTMLElement>) {
         return {
             ...stylingProps.style,
             ...extraStyles,
-            ...prev,
-
-            // Override default z-index from useOverlayPosition. We use isolation: isolate instead.
-            zIndex: undefined
+            ...prev
         };
     });
 


### PR DESCRIPTION
- Fixed an issue where the Image component was logging a warning when the `alt` prop was provided, but empty.
- Fixed an issue where the zIndex should of been forwarded in the popover base component
