### PR TITLE
fix: Multiple Fixes

### DIFF
--- a/.changeset/rotten-radios-exist.md
+++ b/.changeset/rotten-radios-exist.md
@@ -1,0 +1,21 @@
+---
+"@hopper-ui/components": patch
+---
+
+### Hopper Provider
+
+- Typography is now properly set by default.
+
+### Compact Callout
+
+- Ensures a minimum height of `48px`.
+- Removes unnecessary margin when only content is provided.
+- Applies `sm` typography to the content.
+
+### Link
+
+- Typography props like `fontWeight` can now be properly customized directly on the `Link` element.
+
+### Modal
+
+- Heading size is now `lg` by default.

--- a/packages/components/src/Callout/src/CompactCallout.module.css
+++ b/packages/components/src/Callout/src/CompactCallout.module.css
@@ -7,9 +7,8 @@
     --hop-CompactCallout-border-radius: var(--hop-shape-rounded-md);
     --hop-CompactCallout-border-width: 0.0625rem;
     --hop-CompactCallout-border-style: solid;
-    --hop-CompactCallout-grid-template-areas:
-        "content cta dismiss";
-    --hop-CompactCallout-grid-template-columns: 1fr auto auto auto;
+    --hop-CompactCallout-grid-template: "content cta" 1fr / 1fr auto;
+    --hop-CompactCallout-grid-template-dismissable: "content cta dismiss" 1fr / 1fr auto auto;
     --hop-CompactCallout-gap: var(--hop-space-inline-md);
     --hop-CompactCallout-font-size: var(--hop-body-sm-font-size);
     --hop-CompactCallout-font-weight: var(--hop-body-sm-font-weight);
@@ -41,12 +40,10 @@
     --hop-CompactCallout-border-subtle: transparent;
 
     /* Internal Variables */
-    --grid-template-areas: var(--hop-CompactCallout-grid-template-areas);
-    --grid-template-columns: var(--hop-CompactCallout-grid-template-columns);
+    --grid-template: var(--hop-CompactCallout-grid-template);
 
     display: var(--hop-CompactCallout-display);
-    grid-template-areas: var(--grid-template-areas);
-    grid-template-columns: var(--grid-template-columns);
+    grid-template: var(--grid-template);
     column-gap: var(--hop-CompactCallout-gap);
     align-items: var(--hop-CompactCallout-align-items);
 
@@ -62,6 +59,10 @@
     background: var(--background);
     border: var(--border);
     border-radius: var(--hop-CompactCallout-border-radius);
+}
+
+.hop-CompactCallout--dismissable {
+    --grid-template: var(--hop-CompactCallout-grid-template-dismissable);
 }
 
 .hop-CompactCallout__content {

--- a/packages/components/src/Callout/src/CompactCallout.module.css
+++ b/packages/components/src/Callout/src/CompactCallout.module.css
@@ -8,11 +8,14 @@
     --hop-CompactCallout-border-width: 0.0625rem;
     --hop-CompactCallout-border-style: solid;
     --hop-CompactCallout-grid-template-areas:
-        "content button dismiss"
-        "content link dismiss";
-    --hop-CompactCallout-grid-template-columns: 1fr auto auto;
-    --hop-CompactCallout-margin-right-content: var(--hop-space-inline-md);
-    --hop-CompactCallout-margin-right-cta: var(--hop-space-inline-md);
+        "content cta dismiss";
+    --hop-CompactCallout-grid-template-columns: 1fr auto auto auto;
+    --hop-CompactCallout-gap: var(--hop-space-inline-md);
+    --hop-CompactCallout-font-size: var(--hop-body-sm-font-size);
+    --hop-CompactCallout-font-weight: var(--hop-body-sm-font-weight);
+    --hop-CompactCallout-font-family: var(--hop-body-sm-font-family);
+    --hop-CompactCallout-line-height: var(--hop-body-sm-line-height);
+    --hop-CompactCallout-min-block-size: var(--hop-space-480);
 
     /* Information */
     --hop-CompactCallout-border-information: var(--hop-CompactCallout-border-width) var(--hop-CompactCallout-border-style) var(--hop-information-border);
@@ -44,9 +47,17 @@
     display: var(--hop-CompactCallout-display);
     grid-template-areas: var(--grid-template-areas);
     grid-template-columns: var(--grid-template-columns);
+    column-gap: var(--hop-CompactCallout-gap);
     align-items: var(--hop-CompactCallout-align-items);
 
+    box-sizing: border-box;
+    min-block-size: var(--hop-CompactCallout-min-block-size);
     padding: var(--hop-CompactCallout-padding-y) var(--hop-CompactCallout-padding-x);
+
+    font-family: var(--hop-CompactCallout-font-family);
+    font-size: var(--hop-CompactCallout-font-size);
+    font-weight: var(--hop-CompactCallout-font-weight);
+    line-height: var(--hop-CompactCallout-line-height);
 
     background: var(--background);
     border: var(--border);
@@ -55,21 +66,15 @@
 
 .hop-CompactCallout__content {
     grid-area: content;
-    margin-inline-end: var(--hop-CompactCallout-margin-right-content);
     color: var(--color);
 }
 
 .hop-CompactCallout__button {
-    grid-area: button;
+    grid-area: cta;
 }
 
 .hop-CompactCallout__link {
-    grid-area: link;
-}
-
-.hop-CompactCallout:has(.hop-CompactCallout__dismiss) .hop-CompactCallout__button:not(.hop-CompactCallout__dismiss),
-.hop-CompactCallout:has(.hop-CompactCallout__dismiss) .hop-CompactCallout__link {
-    margin-inline-end: var(--hop-CompactCallout-margin-right-cta);
+    grid-area: cta;
 }
 
 .hop-CompactCallout__dismiss {

--- a/packages/components/src/Callout/src/CompactCallout.tsx
+++ b/packages/components/src/Callout/src/CompactCallout.tsx
@@ -31,13 +31,16 @@ const CompactCallout = (props: CompactCalloutProps, ref: ForwardedRef<HTMLDivEle
         ...otherProps
     } = ownProps;
 
+    const isDismissible = onClose !== undefined;
+
     const classNames = clsx(
         GlobalCompactCalloutCssSelector,
         cssModule(
             styles,
             "hop-CompactCallout",
             variant,
-            fillStyle === "subtleFill" && "subtle-fill"
+            fillStyle === "subtleFill" && "subtle-fill",
+            isDismissible && "dismissable"
         ),
         stylingProps.className,
         className
@@ -81,7 +84,7 @@ const CompactCallout = (props: CompactCalloutProps, ref: ForwardedRef<HTMLDivEle
                 ]}
             >
                 {children}
-                {onClose && <CloseButton onPress={onClose} />}
+                {isDismissible && <CloseButton onPress={onClose} />}
             </SlotProvider>
         </div>
     );

--- a/packages/components/src/Callout/src/CompactCallout.tsx
+++ b/packages/components/src/Callout/src/CompactCallout.tsx
@@ -1,7 +1,7 @@
 import { useStyledSystem, type StyledComponentProps } from "@hopper-ui/styled-system";
 import clsx from "clsx";
 import { forwardRef, type CSSProperties, type ForwardedRef } from "react";
-import { useContextProps } from "react-aria-components";
+import { DEFAULT_SLOT, useContextProps } from "react-aria-components";
 
 import { ButtonContext, CloseButton } from "../../buttons/index.ts";
 import { ContentContext } from "../../layout/index.ts";
@@ -62,15 +62,26 @@ const CompactCallout = (props: CompactCalloutProps, ref: ForwardedRef<HTMLDivEle
                         className: styles["hop-CompactCallout__content"]
                     }],
                     [ButtonContext, {
-                        className: styles["hop-CompactCallout__button"]
+                        slots: {
+                            [DEFAULT_SLOT]: {
+                                className: styles["hop-CompactCallout__button"],
+                                variant: "secondary",
+                                size: "sm"
+                            },
+                            close: {
+                                className: styles["hop-CompactCallout__dismiss"]
+                            }
+                        }
                     }],
                     [LinkContext, {
-                        className: styles["hop-CompactCallout__link"]
+                        className: styles["hop-CompactCallout__link"],
+                        variant: "secondary",
+                        size: "sm"
                     }]
                 ]}
             >
                 {children}
-                {onClose && <CloseButton className={styles["hop-CompactCallout__dismiss"]} onPress={onClose} />}
+                {onClose && <CloseButton onPress={onClose} />}
             </SlotProvider>
         </div>
     );

--- a/packages/components/src/Callout/tests/chromatic/CompactCallout.stories.tsx
+++ b/packages/components/src/Callout/tests/chromatic/CompactCallout.stories.tsx
@@ -7,7 +7,10 @@ import { CompactCallout } from "../../src/index.ts";
 
 const meta = {
     title: "Components/Callout/Compact",
-    component: CompactCallout
+    component: CompactCallout,
+    args: {
+        children: <Content>Callout content</Content>
+    }
 } satisfies Meta<typeof CompactCallout>;
 
 export default meta;
@@ -15,93 +18,86 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default = {
-    render: props => (
-        <CompactCallout {...props}>
-            <Content>Callout content</Content>
-        </CompactCallout>
-    )
 } satisfies Story;
 
 export const Inline = {
-    ...Default,
     args: {
         fillStyle: "subtleFill"
     }
 } satisfies Story;
 
 export const Information = {
-    ...Default,
     args: {
         variant: "information"
     }
 } satisfies Story;
 
 export const Warning = {
-    ...Default,
     args: {
         variant: "warning"
     }
 } satisfies Story;
 
 export const Success = {
-    ...Default,
     args: {
         variant: "success"
     }
 } satisfies Story;
 
 export const Upsell = {
-    ...Default,
     args: {
         variant: "upsell"
     }
 } satisfies Story;
 
 export const WithClose = {
-    ...Default,
     args: {
         onClose: () => alert("Closed")
     }
 } satisfies Story;
 
 export const WithCta = {
-    render: props => (
-        <CompactCallout {...props}>
-            <Content>Callout content</Content>
-            <Button variant="secondary" size="sm">Label</Button>
-        </CompactCallout>
-    )
+    args: {
+        children: (
+            <>
+                <Content>Callout content</Content>
+                <Button>Label</Button>
+            </>
+        )
+    }
 } satisfies Story;
 
 export const WithButtonAndCta = {
-    render: props => (
-        <CompactCallout {...props}>
-            <Content>Callout content</Content>
-            <Button variant="secondary" size="sm">Label</Button>
-        </CompactCallout>
-    ),
     args: {
-        onClose: () => alert("Closed")
+        onClose: () => alert("Closed"),
+        children: (
+            <>
+                <Content>Callout content</Content>
+                <Button>Label</Button>
+            </>
+        )
     }
 } satisfies Story;
 
 export const WithLink = {
-    render: props => (
-        <CompactCallout {...props}>
-            <Content>Callout content</Content>
-            <Link variant="secondary" size="sm">Label</Link>
-        </CompactCallout>
-    )
+    args: {
+        children: (
+            <>
+                <Content>Callout content</Content>
+                <Link>Label</Link>
+            </>
+        )
+    }
 } satisfies Story;
 
 export const WithButtonAndLink = {
-    render: props => (
-        <CompactCallout {...props}>
-            <Content>Callout content</Content>
-            <Link variant="secondary" size="sm">Label</Link>
-        </CompactCallout>
-    ),
     args: {
-        onClose: () => alert("Closed")
+        onClose: () => alert("Closed"),
+        children: (
+            <>
+                <Content>Callout content</Content>
+                <Link>Label</Link>
+            </>
+        )
     }
 } satisfies Story;

--- a/packages/components/src/Callout/tests/chromatic/CompactCallout.stories.tsx
+++ b/packages/components/src/Callout/tests/chromatic/CompactCallout.stories.tsx
@@ -101,3 +101,60 @@ export const WithButtonAndLink = {
         )
     }
 } satisfies Story;
+
+export const Overflow = {
+    ...WithButtonAndLink,
+    args: {
+        ...WithButtonAndLink.args,
+        children: (
+            <>
+                <Content>
+                    {new Array(30).fill("Callout content").join(" ")}
+                </Content>
+                <Link>Label</Link>
+            </>
+        )
+    }
+} satisfies Story;
+
+export const OverflowWithClose = {
+    ...WithClose,
+    args: {
+        ...WithClose.args,
+        children: (
+            <Content>
+                {new Array(30).fill("Callout content").join(" ")}
+            </Content>
+        )
+    }
+} satisfies Story;
+
+export const OverflowWithCta = {
+    ...WithLink,
+    args: {
+        ...WithLink.args,
+        children: (
+            <>
+                <Content>
+                    {new Array(30).fill("Callout content").join(" ")}
+                </Content>
+                <Link>Label</Link>
+            </>
+        )
+    }
+} satisfies Story;
+
+export const OverflowWithButtonAndLink = {
+    ...WithButtonAndLink,
+    args: {
+        ...WithButtonAndLink.args,
+        children: (
+            <>
+                <Content>
+                    {new Array(30).fill("Callout content").join(" ")}
+                </Content>
+                <Link>Label</Link>
+            </>
+        )
+    }
+} satisfies Story;

--- a/packages/components/src/HopperProvider/src/HopperProvider.module.css
+++ b/packages/components/src/HopperProvider/src/HopperProvider.module.css
@@ -1,0 +1,8 @@
+.hop-HopperProvider {
+    font-family: var(--hop-body-md-font-family);
+    font-size: var(--hop-body-md-font-size);
+    font-weight: var(--hop-body-md-font-weight);
+    -webkit-font-smoothing: antialiased;
+    line-height: var(--hop-body-md-line-height);
+    color: var(--hop-neutral-text);
+}

--- a/packages/components/src/HopperProvider/src/HopperProvider.tsx
+++ b/packages/components/src/HopperProvider/src/HopperProvider.tsx
@@ -4,6 +4,10 @@ import clsx from "clsx";
 import { createContext, forwardRef, useContext, type ForwardedRef } from "react";
 import { I18nProvider, RouterProvider } from "react-aria-components";
 
+import { cssModule } from "../../utils/index.ts";
+
+import styles from "./HopperProvider.module.css";
+
 export const GlobalHopperProviderCssSelector = "hop-HopperProvider";
 
 export interface HopperProviderProps extends StyledSystemProviderProps {
@@ -98,6 +102,10 @@ const HopperProvider = (props: HopperProviderProps, ref: ForwardedRef<HTMLDivEle
 
     const classNames = clsx(
         GlobalHopperProviderCssSelector,
+        cssModule(
+            styles,
+            "hop-HopperProvider"
+        ),
         className
     );
 

--- a/packages/components/src/Link/src/Link.module.css
+++ b/packages/components/src/Link/src/Link.module.css
@@ -4,6 +4,37 @@
     --hop-Link-color-disabled: var(--hop-neutral-text-disabled);
     --hop-Link-column-gap: var(--hop-space-inline-xs);
 
+    /** Sizes */
+
+    --hop-Link-xs-font-size: var(--hop-body-xs-font-size);
+    --hop-Link-xs-font-family: var(--hop-body-xs-font-family);
+    --hop-Link-xs-font-weight: var(--hop-body-xs-font-weight);
+    --hop-Link-xs-line-height: var(--hop-body-xs-line-height);
+    --hop-Link-sm-font-size: var(--hop-body-sm-font-size);
+    --hop-Link-sm-font-family: var(--hop-body-sm-font-family);
+    --hop-Link-sm-font-weight: var(--hop-body-sm-font-weight);
+    --hop-Link-sm-line-height: var(--hop-body-sm-line-height);
+    --hop-Link-md-font-size: var(--hop-body-md-font-size);
+    --hop-Link-md-font-family: var(--hop-body-md-font-family);
+    --hop-Link-md-font-weight: var(--hop-body-md-font-weight);
+    --hop-Link-md-line-height: var(--hop-body-md-line-height);
+    --hop-Link-lg-font-size: var(--hop-body-lg-font-size);
+    --hop-Link-lg-font-family: var(--hop-body-lg-font-family);
+    --hop-Link-lg-font-weight: var(--hop-body-lg-font-weight);
+    --hop-Link-lg-line-height: var(--hop-body-lg-line-height);
+    --hop-Link-xl-font-size: var(--hop-body-xl-font-size);
+    --hop-Link-xl-font-family: var(--hop-body-xl-font-family);
+    --hop-Link-xl-font-weight: var(--hop-body-xl-font-weight);
+    --hop-Link-xl-line-height: var(--hop-body-xl-line-height);
+    --hop-Link-2xl-font-size: var(--hop-body-2xl-font-size);
+    --hop-Link-2xl-font-family: var(--hop-body-2xl-font-family);
+    --hop-Link-2xl-font-weight: var(--hop-body-2xl-font-weight);
+    --hop-Link-2xl-line-height: var(--hop-body-2xl-line-height);
+    --hop-Link-inherit-size-font-size: inherit;
+    --hop-Link-inherit-size-font-family: inherit;
+    --hop-Link-inherit-size-font-weight: inherit;
+    --hop-Link-inherit-size-line-height: inherit;
+
     /** Primary */
     --hop-Link-primary-text-color: var(--hop-primary-text);
     --hop-Link-primary-text-disabled-color: var(--hop-primary-text-disabled);
@@ -40,6 +71,62 @@
     border-radius: var(--hop-Link-border-radius);
     outline: none;
     outline-offset: 0.125rem;
+}
+
+:where(.hop-Link) {
+    font-family: var(--font-family);
+    font-size: var(--font-size);
+    font-weight: var(--font-weight);
+    line-height: var(--line-height);
+}
+
+:where(.hop-Link--xs) {
+    --font-size: var(--hop-Link-xs-font-size);
+    --font-family: var(--hop-Link-xs-font-family);
+    --font-weight: var(--hop-Link-xs-font-weight);
+    --line-height: var(--hop-Link-xs-line-height);
+}
+
+:where(.hop-Link--sm) {
+    --font-size: var(--hop-Link-sm-font-size);
+    --font-family: var(--hop-Link-sm-font-family);
+    --font-weight: var(--hop-Link-sm-font-weight);
+    --line-height: var(--hop-Link-sm-line-height);
+}
+
+:where(.hop-Link--md) {
+    --font-size: var(--hop-Link-md-font-size);
+    --font-family: var(--hop-Link-md-font-family);
+    --font-weight: var(--hop-Link-md-font-weight);
+    --line-height: var(--hop-Link-md-line-height);
+}
+
+:where(.hop-Link--lg) {
+    --font-size: var(--hop-Link-lg-font-size);
+    --font-family: var(--hop-Link-lg-font-family);
+    --font-weight: var(--hop-Link-lg-font-weight);
+    --line-height: var(--hop-Link-lg-line-height);
+}
+
+:where(.hop-Link--xl) {
+    --font-size: var(--hop-Link-xl-font-size);
+    --font-family: var(--hop-Link-xl-font-family);
+    --font-weight: var(--hop-Link-xl-font-weight);
+    --line-height: var(--hop-Link-xl-line-height);
+}
+
+:where(.hop-Link--2xl) {
+    --font-size: var(--hop-Link-2xl-font-size);
+    --font-family: var(--hop-Link-2xl-font-family);
+    --font-weight: var(--hop-Link-2xl-font-weight);
+    --line-height: var(--hop-Link-2xl-line-height);
+}
+
+:where(.hop-Link--inherit) {
+    --font-size: var(--hop-Link-inherit-size-font-size);
+    --font-family: var(--hop-Link-inherit-size-font-family);
+    --font-weight: var(--hop-Link-inherit-size-font-weight);
+    --line-height: var(--hop-Link-inherit-size-line-height);
 }
 
 /** Focus Ring */

--- a/packages/components/src/Link/src/Link.tsx
+++ b/packages/components/src/Link/src/Link.tsx
@@ -146,7 +146,7 @@ function Link(props: LinkProps, ref: ForwardedRef<HTMLAnchorElement>) {
                     }
                 }],
                 [TextContext, {
-                    size: size,
+                    size: "inherit",
                     className: styles["hop-Link__text"]
                 }]
             ]}

--- a/packages/components/src/Link/tests/chromatic/Link.stories.tsx
+++ b/packages/components/src/Link/tests/chromatic/Link.stories.tsx
@@ -258,6 +258,13 @@ export const StandaloneSecondary: Story = {
     }
 };
 
+export const OverwriteFontWeight: Story = {
+    ...Secondary,
+    args: {
+        ...Secondary.args,
+        fontWeight: "core_505"
+    }
+};
 export const StaticColor: Story = {
     ...Primary,
     decorators: [

--- a/packages/components/src/Modal/src/Modal.tsx
+++ b/packages/components/src/Modal/src/Modal.tsx
@@ -110,6 +110,7 @@ const Modal = (props: ModalProps, ref: ForwardedRef<HTMLDivElement>) => {
                                 }],
                                 [HeadingContext, {
                                     className: styles["hop-Modal__heading"],
+                                    size: "lg",
                                     slot: "title"
                                 }],
                                 [HeaderContext, {

--- a/tooling/storybook-addon/withHopperProvider.tsx
+++ b/tooling/storybook-addon/withHopperProvider.tsx
@@ -63,11 +63,7 @@ export const withHopperProvider = makeDecorator({
                         key={`${colorScheme}`}
                         colorScheme={colorScheme}
                         locale={locale}
-                        color="neutral"
                         backgroundColor="neutral"
-                        lineHeight="body-md"
-                        fontFamily="body-md"
-                        fontSize="body-md"
                         display="flex"
                         flexDirection="column"
 


### PR DESCRIPTION
- Hopper Provider now properly set the typography by default
- Compact Callout fixes: 
    - min height of 48px
    - fix margin that was added unnecessarily when there was a content and nothing else
    - now set the content's typography to sm as expected
- Link fixes:
    -  It is now possible to properly modify the fontweight or any other typography props directly on the link element
- Modal fixes:
    - The size of the heading is now lg by default