### PR TITLE
feat: Extends CSS property types.

### DIFF
--- a/packages/styled-system/src/tokens/tokenMappings.ts
+++ b/packages/styled-system/src/tokens/tokenMappings.ts
@@ -1,4 +1,4 @@
-import type { Globals, Property } from "csstype";
+import type { DataType, Globals, Property } from "csstype";
 
 import type { Breakpoint } from "../responsive/Breakpoints.ts";
 import { type ResponsiveProp, parseResponsiveValue } from "../responsive/useResponsiveValue.tsx";
@@ -151,8 +151,8 @@ export type CssFill = Globals | "child" | "context-fill" | "context-stroke" | "n
 export type CssGrid = "auto" | "max-content" | "min-content" | Globals | Percentage | FRValues;
 export type CssGridTemplate = "none" | "subgrid" | CssGrid;
 export type CssBoxShadow = Globals | "none";
-export type CssBorder = Globals | 0;
-export type CssBorderRadius = Globals | 0;
+export type CssBorder = Globals | 0 | DataType.LineStyle;
+export type CssBorderRadius = Globals | Percentage | 0;
 export type CssGap = Globals | "normal" | 0;
 export type CSSSizing = "auto" | "fit-content" | "max-content" | "min-content" | Globals | Percentage;
 
@@ -189,16 +189,17 @@ export type UNSAFE_FontWeightValue = keyof typeof FontWeightMapping | Property.F
 export type GapValue = keyof typeof SimpleMarginMapping | CssGap;
 export type UNSAFE_GapValue = keyof typeof SimpleMarginMapping | Property.Gap;
 
-export type GridAutoColumnsValue = keyof typeof SizingMapping | CssGrid;
+export type GridAutoColumnsValue = keyof typeof SizingMapping | CssGrid | 0;
 export type UNSAFE_GridAutoColumnsValue = keyof typeof SizingMapping | Property.GridAutoColumns;
 
-export type GridAutoRowsValue = keyof typeof SizingMapping | CssGrid;
+export type GridAutoRowsValue = keyof typeof SizingMapping | CssGrid | 0;
 export type UNSAFE_GridAutoRowsValue = keyof typeof SizingMapping | Property.GridAutoRows;
 
 export type GridTemplateAreasValue = Property.GridTemplateAreas | Array<string>;
 
 export type GridTemplateColumnsValue =
     keyof typeof SizingMapping
+    | 0
     | CssGridTemplate
     | Array<keyof typeof SizingMapping | CssGridTemplate>;
 export type UNSAFE_GridTemplateColumnsValue =
@@ -208,6 +209,7 @@ export type UNSAFE_GridTemplateColumnsValue =
 
 export type GridTemplateRowsValue =
     keyof typeof SizingMapping
+    | 0
     | CssGridTemplate
     | Array<keyof typeof SizingMapping | CssGridTemplate>;
 export type UNSAFE_GridTemplateRowsValue =
@@ -215,32 +217,32 @@ export type UNSAFE_GridTemplateRowsValue =
     | Property.GridTemplateRows
     | Array<keyof typeof SizingMapping | Property.GridTemplateRows>;
 
-export type HeightValue = keyof typeof SizingMapping | CSSSizing;
+export type HeightValue = keyof typeof SizingMapping | CSSSizing | "-moz-max-content" | "-moz-min-content" | "-webkit-fit-content" | 0;
 export type UNSAFE_HeightValue = keyof typeof SizingMapping | Property.Height;
 
-export type LineHeightValue = keyof typeof LineHeightMapping | Globals;
+export type LineHeightValue = keyof typeof LineHeightMapping | Globals | "normal" | 0;
 export type UNSAFE_LineHeightValue = keyof typeof LineHeightMapping | Property.LineHeight;
 
-export type SimpleMarginValue = keyof typeof SimpleMarginMapping | Globals;
+export type SimpleMarginValue = keyof typeof SimpleMarginMapping | Globals | "auto" | 0;
 export type UNSAFE_SimpleMarginValue = keyof typeof SimpleMarginMapping | Property.Margin;
-export type ComplexMarginValue = keyof typeof ComplexMarginMapping | Globals;
+export type ComplexMarginValue = keyof typeof ComplexMarginMapping | Globals | "auto" | 0;
 export type UNSAFE_ComplexMarginValue = keyof typeof ComplexMarginMapping | Property.Margin;
 
-export type SimplePaddingValue = keyof typeof SimplePaddingMapping | Globals;
+export type SimplePaddingValue = keyof typeof SimplePaddingMapping | Globals | 0;
 export type UNSAFE_SimplePaddingValue = keyof typeof SimplePaddingMapping | Property.Padding;
-export type ComplexPaddingValue = keyof typeof ComplexPaddingMapping | Globals;
+export type ComplexPaddingValue = keyof typeof ComplexPaddingMapping | Globals | 0;
 export type UNSAFE_ComplexPaddingValue = keyof typeof ComplexPaddingMapping | Property.Padding;
 
-export type RowGapValue = keyof typeof SimpleMarginMapping | CssGap;
+export type RowGapValue = keyof typeof SimpleMarginMapping | CssGap | 0;
 export type UNSAFE_RowGapValue = keyof typeof SimpleMarginMapping | Property.RowGap;
 
-export type SizingValue = keyof typeof SizingMapping | CSSSizing;
+export type SizingValue = keyof typeof SizingMapping | CSSSizing | "none";
 export type UNSAFE_SizingValue = keyof typeof SizingMapping | Property.Scale;
 
 export type StrokeValue = keyof typeof IconColorMapping | CssFill;
 export type UNSAFE_StrokeValue = keyof typeof IconColorMapping | Property.Stroke;
 
-export type WidthValue = keyof typeof SizingMapping | CSSSizing;
+export type WidthValue = keyof typeof SizingMapping | CSSSizing | 0 | "-moz-max-content" | "-moz-min-content" | "-webkit-fit-content" | "-moz-fit-content" | "-webkit-max-content" | "intrinsic" | "min-intrinsic";
 export type UNSAFE_WidthValue = keyof typeof SizingMapping | Property.Width;
 
 export type GridColumSpanValue = number;


### PR DESCRIPTION
## Description

This change refines several CSS property type definitions within tokenMappings.ts to allow for more valid CSS values. Specifically, it extends the CssBorder type, and adds 0 to the allowed values for properties such as GridAutoColumnsValue, GridAutoRowsValue, GridTemplateColumnsValue, GridTemplateRowsValue, HeightValue, etc.

## Changes

- Updated the CssBorder type definition to include DataType.LineStyle. 
- Added 0 as a valid value for GridAutoColumnsValue, GridAutoRowsValue, GridTemplateColumnsValue, GridTemplateRowsValue. 
- Added additional values such as "-moz-max-content", "-moz-min-content", "-webkit-fit-content" and 0 to HeightValue.
- Added "normal" and 0 to LineHeightValue.
- Added "auto" and 0 to SimpleMarginValue and ComplexMarginValue. Added 0 to SimplePaddingValue and ComplexPaddingValue. 
- Added 0 to RowGapValue.
- Added "none" to SizingValue.
- Added 0, "-moz-max-content", "-moz-min-content", "-webkit-fit-content", "-moz-fit-content", "-webkit-max-content", "intrinsic", and "min-intrinsic" to WidthValue.

## TLDR

The change allows more CSS values to be used within the styled-system, improving flexibility and CSS compatibility. Components using these type definitions will now accept a broader range of values.