### PR TITLE
feat(Avatar): Adds onPress prop to Avatar components

### DIFF
--- a/.changeset/olive-tigers-tease.md
+++ b/.changeset/olive-tigers-tease.md
@@ -1,0 +1,5 @@
+---
+"@hopper-ui/components": patch
+---
+
+Adds `onPress` prop to Avatar components

--- a/apps/docs/content/components/content/Avatar.mdx
+++ b/apps/docs/content/components/content/Avatar.mdx
@@ -96,7 +96,7 @@ An avatar can be disabled.
 
 <Example src="avatar/docs/disabled" />
 
-### Press
+### Pressable
 An avatar can be pressed, which will trigger an action when pressed.
 
 <Example src="avatar/docs/press" />

--- a/apps/docs/content/components/content/Avatar.mdx
+++ b/apps/docs/content/components/content/Avatar.mdx
@@ -96,6 +96,11 @@ An avatar can be disabled.
 
 <Example src="avatar/docs/disabled" />
 
+### Press
+An avatar can be pressed, which will trigger an action.
+
+<Example src="avatar/docs/press" />
+
 ### Customize the image props
 
 Using a custom hook to retry loading the image up to 5 times with a 250ms delay.

--- a/apps/docs/content/components/content/Avatar.mdx
+++ b/apps/docs/content/components/content/Avatar.mdx
@@ -97,7 +97,7 @@ An avatar can be disabled.
 <Example src="avatar/docs/disabled" />
 
 ### Press
-An avatar can be pressed, which will trigger an action.
+An avatar can be pressed, which will trigger an action when pressed.
 
 <Example src="avatar/docs/press" />
 
@@ -124,6 +124,11 @@ When there are too many avatars, a counter will be displayed.
 An avatar group can be displayed in different sizes.
 
 <Example src="avatar/docs/avatar-group/sizes" />
+
+#### Pressable avatars
+An avatar group can have pressable avatars, which will trigger an action when pressed.
+
+<Example src="avatar/docs/avatar-group/pressable" />
 
 #### Max number of avatars
 

--- a/apps/docs/examples/Preview.ts
+++ b/apps/docs/examples/Preview.ts
@@ -440,6 +440,9 @@ export const Previews: Record<string, Preview> = {
     "avatar/docs/disabled": {
         component: lazy(() => import("@/../../packages/components/src/avatar/docs/disabled.tsx"))
     },
+    "avatar/docs/press": {
+        component: lazy(() => import("@/../../packages/components/src/avatar/docs/press.tsx"))
+    },
     "avatar/docs/customization": {
         component: lazy(() => import("@/../../packages/components/src/avatar/docs/customization.tsx"))
     },

--- a/apps/docs/examples/Preview.ts
+++ b/apps/docs/examples/Preview.ts
@@ -455,6 +455,9 @@ export const Previews: Record<string, Preview> = {
     "avatar/docs/avatar-group/sizes": {
         component: lazy(() => import("@/../../packages/components/src/avatar/docs/avatar-group/sizes.tsx"))
     },
+    "avatar/docs/avatar-group/pressable": {
+        component: lazy(() => import("@/../../packages/components/src/avatar/docs/avatar-group/pressable.tsx"))
+    },
     "avatar/docs/avatar-group/maxNumberOfAvatars": {
         component: lazy(() => import("@/../../packages/components/src/avatar/docs/avatar-group/maxNumberOfAvatars.tsx"))
     },

--- a/packages/components/src/avatar/docs/avatar-group/pressable.tsx
+++ b/packages/components/src/avatar/docs/avatar-group/pressable.tsx
@@ -1,0 +1,11 @@
+import { Avatar, AvatarGroup } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <AvatarGroup>
+            <Avatar name="John Doe" onPress={() => alert("John Doe")} />
+            <Avatar name="Alex Turner" />
+            <Avatar name="Chris Dalton" onPress={() => alert("Chris Dalton")} />
+        </AvatarGroup>
+    );
+}

--- a/packages/components/src/avatar/docs/migration-notes.md
+++ b/packages/components/src/avatar/docs/migration-notes.md
@@ -1,3 +1,4 @@
 Coming from Orbiter, you should be aware of the following changes:
 
 - `retryCount` has been removed.
+- `onClick` has been renamed to `onPress` to be closer to the [React Aria API](https://react-spectrum.adobe.com/react-aria/Button.html#events).

--- a/packages/components/src/avatar/docs/press.tsx
+++ b/packages/components/src/avatar/docs/press.tsx
@@ -1,0 +1,17 @@
+import { AnonymousAvatar, Avatar, BrokenAvatar, DeletedAvatar, Inline } from "@hopper-ui/components";
+import { useCallback } from "react";
+
+export default function Example() {
+    const handlePress = useCallback(() => {
+        alert("Avatar pressed!");
+    }, []);
+
+    return (
+        <Inline>
+            <Avatar name="John Doe" onPress={handlePress} />
+            <DeletedAvatar aria-label="Deleted User" onPress={handlePress} />
+            <AnonymousAvatar aria-label="Anonymous User" onPress={handlePress} />
+            <BrokenAvatar aria-label="Broken User" onPress={handlePress} />
+        </Inline>
+    );
+}

--- a/packages/components/src/avatar/src/AnonymousAvatar.tsx
+++ b/packages/components/src/avatar/src/AnonymousAvatar.tsx
@@ -1,10 +1,10 @@
 import { AnonymousRichIcon } from "@hopper-ui/icons";
 import { type ResponsiveProp, type StyledSystemProps, useResponsiveValue, useStyledSystem } from "@hopper-ui/styled-system";
 import { type ForwardedRef, forwardRef } from "react";
-import { mergeProps } from "react-aria";
+import { mergeProps, type PressEvent } from "react-aria";
 import { composeRenderProps, useContextProps } from "react-aria-components";
 
-import { type AccessibleSlotProps, type RenderProps, composeClassnameRenderProps, useRenderProps } from "../../utils/index.ts";
+import { type AccessibleSlotProps, composeClassnameRenderProps, type RenderProps, useRenderProps } from "../../utils/index.ts";
 
 import type { AvatarSize } from "./Avatar.tsx";
 import { AvatarContext } from "./AvatarContext.ts";
@@ -29,6 +29,10 @@ export interface AnonymousAvatarProps extends StyledSystemProps, AccessibleSlotP
      * * @default "md"
      */
     size?: ResponsiveProp<AvatarSize>;
+    /**
+     * Called when the avatar is pressed
+     */
+    onPress?: (event: PressEvent) => void;
 }
 
 function AnonymousAvatar(props: AnonymousAvatarProps, ref: ForwardedRef<HTMLDivElement>) {

--- a/packages/components/src/avatar/src/Avatar.module.css
+++ b/packages/components/src/avatar/src/Avatar.module.css
@@ -57,6 +57,7 @@
 
     background-color: var(--background-color, transparent);
     border-radius: var(--hop-Avatar-border-radius);
+    outline: none;
 }
 
 .hop-Avatar--xs {
@@ -81,6 +82,14 @@
 
 .hop-Avatar--2xl {
     --size: var(--hop-Avatar-2xl-size);
+}
+
+.hop-Avatar--clickable {
+    cursor: pointer;
+}
+
+.hop-Avatar--focus-visible {
+    outline: 0.125rem solid var(--hop-primary-border-focus);
 }
 
 /* Colors */

--- a/packages/components/src/avatar/src/Avatar.tsx
+++ b/packages/components/src/avatar/src/Avatar.tsx
@@ -23,6 +23,10 @@ interface AvatarRenderProps {
      * Whether or not the avatar is disabled.
      */
     isDisabled?: boolean;
+    /**
+     * Whether or not the avatar is focus visible.
+     */
+    isFocusVisible?: boolean;
 }
 
 export interface AvatarProps extends StyledSystemProps, AccessibleSlotProps, Omit<RenderProps<AvatarRenderProps>, "children"> {
@@ -184,7 +188,8 @@ function Avatar(props: AvatarProps, ref: ForwardedRef<HTMLDivElement>) {
         className: classNames,
         style: mergedStyles,
         values: {
-            isDisabled: isDisabled || false
+            isDisabled: isDisabled || false,
+            isFocusVisible: isFocusVisible || false
         }
     });
 

--- a/packages/components/src/avatar/src/Avatar.tsx
+++ b/packages/components/src/avatar/src/Avatar.tsx
@@ -1,7 +1,8 @@
 import { type ResponsiveProp, slot as slotFn, type StyledSystemProps, useResponsiveValue, useStyledSystem } from "@hopper-ui/styled-system";
 import { filterDOMProps, mergeProps } from "@react-aria/utils";
-import { type ForwardedRef, forwardRef, type HTMLProps, type ReactElement, useMemo } from "react";
-import { composeRenderProps, useContextProps } from "react-aria-components";
+import { type ComponentProps, type ForwardedRef, forwardRef, type HTMLProps, type ReactElement, useMemo } from "react";
+import { useFocusRing } from "react-aria";
+import { composeRenderProps, Pressable, type PressEvent, useContextProps } from "react-aria-components";
 
 import { Text, type TextSize } from "../../typography/index.ts";
 import { type AccessibleSlotProps, ClearContainerSlots, composeClassnameRenderProps, cssModule, type RenderProps, type SizeAdapter, useRenderProps } from "../../utils/index.ts";
@@ -51,6 +52,10 @@ export interface AvatarProps extends StyledSystemProps, AccessibleSlotProps, Omi
      * The src of the image to display. If not provided, the initials will be displayed instead.
      */
     src?: string;
+    /**
+     * Called when the avatar is pressed
+     */
+    onPress?: (event: PressEvent) => void;
 }
 
 export const AvatarToTextSizeAdapter: SizeAdapter<AvatarSize, TextSize> = {
@@ -132,11 +137,13 @@ function Avatar(props: AvatarProps, ref: ForwardedRef<HTMLDivElement>) {
         slot,
         src,
         className,
+        onPress,
         style,
         ...otherProps
     } = ownProps;
     const domProps = filterDOMProps(otherProps);
 
+    const { focusProps, isFocusVisible } = useFocusRing({ within: true });
     const { onError, onLoad, ...otherImageProps } = imageProps ?? {};
     const { imageUrl, status } = useImageFallback({ src, fallbackSrc, onError, onLoad });
     const imageLoaded = status === "loaded";
@@ -147,6 +154,7 @@ function Avatar(props: AvatarProps, ref: ForwardedRef<HTMLDivElement>) {
     const isBrokenImage = imageFailed && !isFallbackInitials;
     const isImage = src && !imageFailed && imageLoaded;
     const isInitials = !src || (!isImage && isFallbackInitials);
+    const isClickable = !!onPress;
 
     const classNames = composeClassnameRenderProps(
         className,
@@ -157,7 +165,9 @@ function Avatar(props: AvatarProps, ref: ForwardedRef<HTMLDivElement>) {
             size,
             isBrokenImage && "broken-image",
             isImage && "image",
-            isInitials && getColorName(name)
+            isInitials && getColorName(name),
+            isClickable && "clickable",
+            isFocusVisible && "focus-visible"
         ),
         stylingProps.className
     );
@@ -212,12 +222,11 @@ function Avatar(props: AvatarProps, ref: ForwardedRef<HTMLDivElement>) {
         />;
     }
 
-    return (
+    const avatar = (extraProps: ComponentProps<"div">) => (
         <div
-            {...mergeProps(domProps, renderProps)}
+            {...mergeProps(domProps, renderProps, extraProps)}
             aria-label={ariaLabel ?? name}
             data-disabled={isDisabled || undefined}
-            role="img"
             slot={slot ?? undefined}
             ref={ref}
         >
@@ -226,6 +235,17 @@ function Avatar(props: AvatarProps, ref: ForwardedRef<HTMLDivElement>) {
             </ClearContainerSlots>
         </div>
     );
+
+    if (onPress) {
+        return <Pressable onPress={onPress}>
+            {avatar({
+                ...focusProps,
+                role: "button"
+            })}
+        </Pressable>;
+    }
+
+    return avatar({ role: "img" });
 }
 
 /**

--- a/packages/components/src/avatar/src/BrokenAvatar.tsx
+++ b/packages/components/src/avatar/src/BrokenAvatar.tsx
@@ -1,10 +1,10 @@
 import { BrokenImageRichIcon } from "@hopper-ui/icons";
 import { type ResponsiveProp, type StyledSystemProps, useResponsiveValue, useStyledSystem } from "@hopper-ui/styled-system";
 import { type ForwardedRef, forwardRef } from "react";
-import { mergeProps } from "react-aria";
+import { mergeProps, type PressEvent } from "react-aria";
 import { composeRenderProps, useContextProps } from "react-aria-components";
 
-import { type AccessibleSlotProps, type RenderProps, composeClassnameRenderProps, useRenderProps } from "../../utils/index.ts";
+import { type AccessibleSlotProps, composeClassnameRenderProps, type RenderProps, useRenderProps } from "../../utils/index.ts";
 
 import type { AvatarSize } from "./Avatar.tsx";
 import { AvatarContext } from "./AvatarContext.ts";
@@ -30,6 +30,10 @@ export interface BrokenAvatarProps extends StyledSystemProps, AccessibleSlotProp
      * * @default "md"
      */
     size?: ResponsiveProp<AvatarSize>;
+    /**
+     * Called when the avatar is pressed
+     */
+    onPress?: (event: PressEvent) => void;
 }
 
 function BrokenAvatar(props: BrokenAvatarProps, ref: ForwardedRef<HTMLDivElement>) {

--- a/packages/components/src/avatar/src/DeletedAvatar.tsx
+++ b/packages/components/src/avatar/src/DeletedAvatar.tsx
@@ -1,10 +1,10 @@
 import { DeletedUserRichIcon } from "@hopper-ui/icons";
 import { type ResponsiveProp, type StyledSystemProps, useResponsiveValue, useStyledSystem } from "@hopper-ui/styled-system";
 import { type ForwardedRef, forwardRef } from "react";
-import { mergeProps } from "react-aria";
+import { mergeProps, type PressEvent } from "react-aria";
 import { composeRenderProps, useContextProps } from "react-aria-components";
 
-import { type AccessibleSlotProps, type RenderProps, composeClassnameRenderProps, useRenderProps } from "../../utils/index.ts";
+import { type AccessibleSlotProps, composeClassnameRenderProps, type RenderProps, useRenderProps } from "../../utils/index.ts";
 
 import type { AvatarSize } from "./Avatar.tsx";
 import { AvatarContext } from "./AvatarContext.ts";
@@ -30,6 +30,10 @@ export interface DeletedAvatarProps extends StyledSystemProps, AccessibleSlotPro
      * * @default "md"
      */
     size?: ResponsiveProp<AvatarSize>;
+    /**
+     * Called when the avatar is pressed
+     */
+    onPress?: (event: PressEvent) => void;
 }
 
 function DeletedAvatar(props: DeletedAvatarProps, ref: ForwardedRef<HTMLDivElement>) {

--- a/packages/components/src/avatar/src/RichIconAvatarImage.module.css
+++ b/packages/components/src/avatar/src/RichIconAvatarImage.module.css
@@ -38,9 +38,10 @@
     block-size: var(--size, var(--hop-RichIconAvatarImage-md-size));
 
     color: var(--hop-RichIconAvatarImage-icon-color);
-    
+
     background-color: var(--background-color);
     border-radius: var(--hop-RichIconAvatarImage-border-radius);
+    outline: none;
 }
 
 .hop-RichIconAvatarImage--xs {
@@ -71,6 +72,14 @@
 .hop-RichIconAvatarImage--2xl {
     --size: var(--hop-RichIconAvatarImage-2xl-size);
     --icon-size: var(--hop-RichIconAvatarImage-icon-2xl-size);
+}
+
+.hop-RichIconAvatarImage--clickable {
+    cursor: pointer;
+}
+
+.hop-RichIconAvatarImage--focus-visible {
+    outline: 0.125rem solid var(--hop-primary-border-focus);
 }
 
 .hop-RichIconAvatarImage[data-disabled] {

--- a/packages/components/src/avatar/src/RichIconAvatarImage.tsx
+++ b/packages/components/src/avatar/src/RichIconAvatarImage.tsx
@@ -18,6 +18,10 @@ interface RichIconAvatarImageRenderProps {
      * Whether or not the avatar is disabled.
      */
     isDisabled?: boolean;
+    /**
+     * Whether or not the avatar is focus visible.
+     */
+    isFocusVisible?: boolean;
 }
 
 type OmittedDivProps = "slot" | "content" | "color" | "children" | "className" | "style";
@@ -89,7 +93,8 @@ function RichIconAvatarImage(props: RichIconAvatarImageProps, ref: ForwardedRef<
         className: classNames,
         style: mergedStyles,
         values: {
-            isDisabled: isDisabled || false
+            isDisabled: isDisabled || false,
+            isFocusVisible: isFocusVisible || false
         }
     });
 

--- a/packages/components/src/avatar/tests/jest/AnonymousAvatar.test.tsx
+++ b/packages/components/src/avatar/tests/jest/AnonymousAvatar.test.tsx
@@ -22,6 +22,14 @@ describe("AnonymousAvatar", () => {
         expect(element).toHaveClass("test");
     });
 
+    it("should have role button when there's a onPress event", () => {
+        render(<AnonymousAvatar aria-label="John Doe" onPress={() => {}} />);
+
+        const element = screen.getByRole("button", { name: "John Doe" });
+
+        expect(element).toBeInTheDocument();
+    });
+
     it("should support custom style", () => {
         render(<AnonymousAvatar aria-label="John Doe" marginTop="stack-sm" style={{ marginBottom: "13px" }} />);
 

--- a/packages/components/src/avatar/tests/jest/Avatar.test.tsx
+++ b/packages/components/src/avatar/tests/jest/Avatar.test.tsx
@@ -22,6 +22,14 @@ describe("Avatar", () => {
         expect(element).toHaveClass("test");
     });
 
+    it("should have role button when there's a onPress event", () => {
+        render(<Avatar name="John Doe" onPress={() => {}} />);
+
+        const element = screen.getByRole("button", { name: "John Doe" });
+
+        expect(element).toBeInTheDocument();
+    });
+
     it("should support custom style", () => {
         render(<Avatar name="John Doe" marginTop="stack-sm" style={{ marginBottom: "13px" }} />);
 

--- a/packages/components/src/avatar/tests/jest/BrokenAvatar.test.tsx
+++ b/packages/components/src/avatar/tests/jest/BrokenAvatar.test.tsx
@@ -22,6 +22,14 @@ describe("BrokenAvatar", () => {
         expect(element).toHaveClass("test");
     });
 
+    it("should have role button when there's a onPress event", () => {
+        render(<BrokenAvatar aria-label="John Doe" onPress={() => {}} />);
+
+        const element = screen.getByRole("button", { name: "John Doe" });
+
+        expect(element).toBeInTheDocument();
+    });
+
     it("should support custom style", () => {
         render(<BrokenAvatar aria-label="John Doe" marginTop="stack-sm" style={{ marginBottom: "13px" }} />);
 

--- a/packages/components/src/avatar/tests/jest/DeletedAvatar.test.tsx
+++ b/packages/components/src/avatar/tests/jest/DeletedAvatar.test.tsx
@@ -22,6 +22,14 @@ describe("DeletedAvatar", () => {
         expect(element).toHaveClass("test");
     });
 
+    it("should have role button when there's a onPress event", () => {
+        render(<DeletedAvatar aria-label="John Doe" onPress={() => {}} />);
+
+        const element = screen.getByRole("button", { name: "John Doe" });
+
+        expect(element).toBeInTheDocument();
+    });
+
     it("should support custom style", () => {
         render(<DeletedAvatar aria-label="John Doe" marginTop="stack-sm" style={{ marginBottom: "13px" }} />);
 

--- a/packages/components/src/spinner/docs/migration-notes.md
+++ b/packages/components/src/spinner/docs/migration-notes.md
@@ -1,4 +1,3 @@
 Coming from Orbiter, you should be aware of the following changes:
 
 - The `color` props will only affect the spinner's text color and not the color of the tracks.
-- Use the `variant` prop to change the color of the tracks, which offers `default`, `white` and `black` options.


### PR DESCRIPTION
Enables the Avatar, AnonymousAvatar, BrokenAvatar, DeletedAvatar, and RichIconAvatarImage components to handle press events.

This change introduces the `onPress` prop, allowing developers to attach custom actions when the avatar is clicked or pressed. The Avatar component now renders as a button when the `onPress` prop is provided, enhancing interactivity.