### PR TITLE
feat: Adds documentation for PopoverBase component

### DIFF
--- a/apps/docs/content/components/internal-parts/PopoverBase.mdx
+++ b/apps/docs/content/components/internal-parts/PopoverBase.mdx
@@ -6,15 +6,10 @@ links:
     source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/overlays/popover/src/PopoverBase.tsx
 ---
 
-The PopoverBase component is an internal building block that provides the core popover functionality with Hopper's styling.
-It's a wrapper around React Aria's Popover component that adds Hopper's design system styling and additional features.
+PopoverBase is a low-level building block that wraps React Aria's Popover to provide core popover functionality with Hopper's design system styling and enhancements.
+It doesn't impose layout or padding, making it ideal for building custom popover structures from scratch.
 
-## When to use
-
-PopoverBase is primarily intended as an internal component for building higher-level components.
-You should use it when you're building a custom overlay component that requires popover functionality.
-
-## Basic usage
+## Usage
 
 PopoverBase should be used with `PopoverTrigger` to handle the opening and closing of the popover:
 

--- a/apps/docs/content/components/internal-parts/PopoverBase.mdx
+++ b/apps/docs/content/components/internal-parts/PopoverBase.mdx
@@ -1,0 +1,25 @@
+---
+title: PopoverBase
+description: A simple React Aria Popover with hopper's styling
+category: "internal parts"
+links:
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/overlays/popover/src/PopoverBase.tsx
+---
+
+The PopoverBase component is an internal building block that provides the core popover functionality with Hopper's styling.
+It's a wrapper around React Aria's Popover component that adds Hopper's design system styling and additional features.
+
+## When to use
+
+PopoverBase is primarily intended as an internal component for building higher-level components.
+You should use it when you're building a custom overlay component that requires popover functionality.
+
+## Basic usage
+
+PopoverBase should be used with `PopoverTrigger` to handle the opening and closing of the popover:
+
+<Example src="overlays/popover/docs/popover-base/preview" isOpen />
+
+## Props
+
+<PropTable component="PopoverBase" />

--- a/apps/docs/examples/Preview.ts
+++ b/apps/docs/examples/Preview.ts
@@ -980,6 +980,9 @@ export const Previews: Record<string, Preview> = {
     "helper-message/docs/noicon": {
         component: lazy(() => import("@/../../packages/components/src/helper-message/docs/noicon.tsx"))
     },
+    "overlays/popover/docs/popover-base/preview": {
+        component: lazy(() => import("@/../../packages/components/src/overlays/popover/docs/popover-base/preview.tsx"))
+    },
     "layout/docs/flex/preview": {
         component: lazy(() => import("@/../../packages/components/src/layout/docs/flex/preview.tsx"))
     },

--- a/packages/components/src/overlays/popover/docs/popover-base/preview.tsx
+++ b/packages/components/src/overlays/popover/docs/popover-base/preview.tsx
@@ -1,0 +1,12 @@
+import { Button, PopoverBase, PopoverTrigger } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <PopoverTrigger>
+            <Button aria-label="trigger" variant="secondary">Trigger</Button>
+            <PopoverBase>
+                Frogs can breathe through their skin
+            </PopoverBase>
+        </PopoverTrigger>
+    );
+}

--- a/packages/components/src/overlays/popover/src/PopoverBase.tsx
+++ b/packages/components/src/overlays/popover/src/PopoverBase.tsx
@@ -85,7 +85,7 @@ function PopoverBase(props: PopoverBaseProps, ref: ForwardedRef<HTMLElement>) {
 /**
  * A simple React Aria Popover with hopper's styling
  *
- * [View Documentation](https://hopper.workleap.design/components/Popover)
+ * [View Documentation](https://hopper.workleap.design/components/PopoverBase)
  */
 const _PopoverBase = forwardRef<HTMLElement, PopoverBaseProps>(PopoverBase);
 _PopoverBase.displayName = "PopoverBase";


### PR DESCRIPTION
Introduces documentation for the `PopoverBase` component, an internal building block that provides core popover functionality with Hopper's styling.

Includes a basic usage example and a link to the component's props table.