### PR TITLE
feat: Document HTML elements

### DIFF
--- a/apps/docs/content/components/html-elements/A.mdx
+++ b/apps/docs/content/components/html-elements/A.mdx
@@ -1,6 +1,6 @@
 ---
 title: A
-description: A specialized box component for HTML anchor element.
+description: A specialized component to represent an HTML anchor element.
 category: "html elements"
 ---
 

--- a/apps/docs/content/components/html-elements/A.mdx
+++ b/apps/docs/content/components/html-elements/A.mdx
@@ -1,0 +1,12 @@
+---
+title: A
+description: A specialized box component for HTML anchor element.
+category: "html elements"
+---
+
+<Example src="html-elements/docs/aPreview" isOpen />
+
+## Usage
+
+An anchor component accepts all the [anchor HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a) and [Hopper styled component props](/styled-system/concepts/styling).
+

--- a/apps/docs/content/components/html-elements/Address.mdx
+++ b/apps/docs/content/components/html-elements/Address.mdx
@@ -1,0 +1,11 @@
+---
+title: Address
+description: A specialized box component for HTML address element.
+category: "html elements"
+---
+
+<Example src="html-elements/docs/addressPreview" isOpen />
+
+## Usage
+
+An address component accepts all the [address HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/address) and [Hopper styled component props](/styled-system/concepts/styling).

--- a/apps/docs/content/components/html-elements/Address.mdx
+++ b/apps/docs/content/components/html-elements/Address.mdx
@@ -1,6 +1,6 @@
 ---
 title: Address
-description: A specialized box component for HTML address element.
+description: A specialized component to represent an HTML address element.
 category: "html elements"
 ---
 

--- a/apps/docs/content/components/html-elements/Article.mdx
+++ b/apps/docs/content/components/html-elements/Article.mdx
@@ -1,6 +1,6 @@
 ---
 title: Article
-description: A specialized box component for HTML article element.
+description: A specialized component to represent an HTML article element.
 category: "html elements"
 ---
 

--- a/apps/docs/content/components/html-elements/Article.mdx
+++ b/apps/docs/content/components/html-elements/Article.mdx
@@ -1,0 +1,12 @@
+---
+title: Article
+description: A specialized box component for HTML article element.
+category: "html elements"
+---
+
+<Example src="html-elements/docs/articlePreview" isOpen />
+
+## Usage
+
+An article component accepts all the [article HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/article) and [Hopper styled component props](/styled-system/concepts/styling).
+

--- a/apps/docs/content/components/html-elements/Aside.mdx
+++ b/apps/docs/content/components/html-elements/Aside.mdx
@@ -1,6 +1,6 @@
 ---
 title: Aside
-description: A specialized box component for HTML aside element.
+description: A specialized component to represent an HTML aside element.
 category: "html elements"
 ---
 

--- a/apps/docs/content/components/html-elements/Aside.mdx
+++ b/apps/docs/content/components/html-elements/Aside.mdx
@@ -1,0 +1,11 @@
+---
+title: Aside
+description: A specialized box component for HTML aside element.
+category: "html elements"
+---
+
+<Example src="html-elements/docs/asidePreview" isOpen />
+
+## Usage
+
+An aside component accepts all the [aside HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/aside) and [Hopper styled component props](/styled-system/concepts/styling).

--- a/apps/docs/content/components/html-elements/Button.mdx
+++ b/apps/docs/content/components/html-elements/Button.mdx
@@ -1,0 +1,12 @@
+---
+title: HTMLButton
+description: A specialized button component for HTML button element.
+category: "html elements"
+---
+
+<Example src="html-elements/docs/buttonPreview" isOpen />
+
+## Usage
+
+A button component accepts all the [button HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button) and [Hopper styled component props](/styled-system/concepts/styling).
+

--- a/apps/docs/content/components/html-elements/Div.mdx
+++ b/apps/docs/content/components/html-elements/Div.mdx
@@ -1,6 +1,6 @@
 ---
 title: Div
-description: A specialized box component for HTML div element.
+description: A specialized component to represent an HTML div element.
 category: "html elements"
 ---
 

--- a/apps/docs/content/components/html-elements/Div.mdx
+++ b/apps/docs/content/components/html-elements/Div.mdx
@@ -1,0 +1,11 @@
+---
+title: Div
+description: A specialized box component for HTML div element.
+category: "html elements"
+---
+
+<Example src="html-elements/docs/divPreview" isOpen />
+
+## Usage
+
+A div component accepts all the [div HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/div) and [Hopper styled component props](/styled-system/concepts/styling).

--- a/apps/docs/content/components/html-elements/Footer.mdx
+++ b/apps/docs/content/components/html-elements/Footer.mdx
@@ -1,0 +1,12 @@
+---
+title: HTMLFooter
+description: A specialized box component for HTML footer element.
+category: "html elements"
+---
+
+<Example src="html-elements/docs/footerPreview" isOpen />
+
+## Usage
+
+An footer component accepts all the [footer HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/footer) and [Hopper styled component props](/styled-system/concepts/styling).
+

--- a/apps/docs/content/components/html-elements/Footer.mdx
+++ b/apps/docs/content/components/html-elements/Footer.mdx
@@ -1,6 +1,6 @@
 ---
 title: HTMLFooter
-description: A specialized box component for HTML footer element.
+description: A specialized component to represent an HTML footer element.
 category: "html elements"
 ---
 

--- a/apps/docs/content/components/html-elements/Header.mdx
+++ b/apps/docs/content/components/html-elements/Header.mdx
@@ -1,0 +1,12 @@
+---
+title: HTMLHeader
+description: A specialized box component for HTML header element.
+category: "html elements"
+---
+
+<Example src="html-elements/docs/headerPreview" isOpen />
+
+## Usage
+
+An header component accepts all the [header HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/header) and [Hopper styled component props](/styled-system/concepts/styling).
+

--- a/apps/docs/content/components/html-elements/Header.mdx
+++ b/apps/docs/content/components/html-elements/Header.mdx
@@ -1,6 +1,6 @@
 ---
 title: HTMLHeader
-description: A specialized box component for HTML header element.
+description: A specialized component to represent an HTML header element.
 category: "html elements"
 ---
 

--- a/apps/docs/content/components/html-elements/Img.mdx
+++ b/apps/docs/content/components/html-elements/Img.mdx
@@ -1,0 +1,12 @@
+---
+title: Img
+description: A specialized box component for HTML img element.
+category: "html elements"
+---
+
+<Example src="html-elements/docs/imgPreview" isOpen />
+
+## Usage
+
+An img component accepts all the [img HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img) and [Hopper styled component props](/styled-system/concepts/styling).
+

--- a/apps/docs/content/components/html-elements/Img.mdx
+++ b/apps/docs/content/components/html-elements/Img.mdx
@@ -1,6 +1,6 @@
 ---
 title: Img
-description: A specialized box component for HTML img element.
+description: A specialized component to represent an HTML img element.
 category: "html elements"
 ---
 

--- a/apps/docs/content/components/html-elements/Input.mdx
+++ b/apps/docs/content/components/html-elements/Input.mdx
@@ -1,0 +1,13 @@
+
+---
+title: Input
+description: A specialized box component for HTML input element.
+category: "html elements"
+---
+
+<Example src="html-elements/docs/inputPreview" isOpen />
+
+## Usage
+
+An input component accepts all the [input HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input) and [Hopper styled component props](/styled-system/concepts/styling).
+

--- a/apps/docs/content/components/html-elements/Input.mdx
+++ b/apps/docs/content/components/html-elements/Input.mdx
@@ -1,7 +1,7 @@
 
 ---
 title: Input
-description: A specialized box component for HTML input element.
+description: A specialized component to represent an HTML input element.
 category: "html elements"
 ---
 

--- a/apps/docs/content/components/html-elements/List.mdx
+++ b/apps/docs/content/components/html-elements/List.mdx
@@ -1,0 +1,12 @@
+---
+title: List
+description: A specialized box component for HTML ul/ol/li element.
+category: "html elements"
+---
+
+<Example src="html-elements/docs/listPreview" isOpen />
+
+## Usage
+
+A list component accepts all the [ul](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ul), [ol](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ol), and [li](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/li) HTML element attributes and [Hopper styled component props](/styled-system/concepts/styling).
+

--- a/apps/docs/content/components/html-elements/List.mdx
+++ b/apps/docs/content/components/html-elements/List.mdx
@@ -1,6 +1,6 @@
 ---
 title: List
-description: A specialized box component for HTML ul/ol/li element.
+description: A specialized component to represent an HTML ul/ol/li element.
 category: "html elements"
 ---
 

--- a/apps/docs/content/components/html-elements/Main.mdx
+++ b/apps/docs/content/components/html-elements/Main.mdx
@@ -1,6 +1,6 @@
 ---
 title: Main
-description: A specialized box component for HTML main element.
+description: A specialized component to represent an HTML main element.
 category: "html elements"
 ---
 

--- a/apps/docs/content/components/html-elements/Main.mdx
+++ b/apps/docs/content/components/html-elements/Main.mdx
@@ -1,0 +1,11 @@
+---
+title: Main
+description: A specialized box component for HTML main element.
+category: "html elements"
+---
+
+<Example src="html-elements/docs/mainPreview" isOpen />
+
+## Usage
+
+A main component accepts all the [main HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/main) and [Hopper styled component props](/styled-system/concepts/styling).

--- a/apps/docs/content/components/html-elements/Nav.mdx
+++ b/apps/docs/content/components/html-elements/Nav.mdx
@@ -1,6 +1,6 @@
 ---
 title: Nav
-description: A specialized box component for HTML nav element.
+description: A specialized component to represent an HTML nav element.
 category: "html elements"
 ---
 

--- a/apps/docs/content/components/html-elements/Nav.mdx
+++ b/apps/docs/content/components/html-elements/Nav.mdx
@@ -1,0 +1,11 @@
+---
+title: Nav
+description: A specialized box component for HTML nav element.
+category: "html elements"
+---
+
+<Example src="html-elements/docs/navPreview" isOpen />
+
+## Usage
+
+A nav component accepts all the [nav HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/nav) and [Hopper styled component props](/styled-system/concepts/styling).

--- a/apps/docs/content/components/html-elements/Section.mdx
+++ b/apps/docs/content/components/html-elements/Section.mdx
@@ -1,0 +1,11 @@
+---
+title: Section
+description: A specialized box component for HTML section element.
+category: "html elements"
+---
+
+<Example src="html-elements/docs/sectionPreview" isOpen />
+
+## Usage
+
+A section component accepts all the [section HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/section) and [Hopper styled component props](/styled-system/concepts/styling).

--- a/apps/docs/content/components/html-elements/Section.mdx
+++ b/apps/docs/content/components/html-elements/Section.mdx
@@ -1,6 +1,6 @@
 ---
 title: Section
-description: A specialized box component for HTML section element.
+description: A specialized component to represent an HTML section element.
 category: "html elements"
 ---
 

--- a/apps/docs/content/components/html-elements/Span.mdx
+++ b/apps/docs/content/components/html-elements/Span.mdx
@@ -1,6 +1,6 @@
 ---
 title: Span
-description: A specialized box component for HTML span element.
+description: A specialized component to represent an HTML span element.
 category: "html elements"
 ---
 

--- a/apps/docs/content/components/html-elements/Span.mdx
+++ b/apps/docs/content/components/html-elements/Span.mdx
@@ -1,0 +1,11 @@
+---
+title: Span
+description: A specialized box component for HTML span element.
+category: "html elements"
+---
+
+<Example src="html-elements/docs/spanPreview" isOpen />
+
+## Usage
+
+A span component accepts all the [span HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/span) and [Hopper styled component props](/styled-system/concepts/styling).

--- a/apps/docs/content/components/html-elements/Table.mdx
+++ b/apps/docs/content/components/html-elements/Table.mdx
@@ -1,0 +1,11 @@
+---
+title: Table
+description: A specialized box component for HTML table element.
+category: "html elements"
+---
+
+<Example src="html-elements/docs/tablePreview" isOpen />
+
+## Usage
+
+A table component accepts all the [table HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/table) and [Hopper styled component props](/styled-system/concepts/styling).

--- a/apps/docs/content/components/html-elements/Table.mdx
+++ b/apps/docs/content/components/html-elements/Table.mdx
@@ -1,6 +1,6 @@
 ---
 title: Table
-description: A specialized box component for HTML table element.
+description: A specialized component to represent an HTML table element.
 category: "html elements"
 ---
 

--- a/apps/docs/examples/Preview.ts
+++ b/apps/docs/examples/Preview.ts
@@ -944,6 +944,54 @@ export const Previews: Record<string, Preview> = {
     "inputs/docs/text-field/fluid": {
         component: lazy(() => import("@/../../packages/components/src/inputs/docs/text-field/fluid.tsx"))
     },
+    "html-elements/docs/aPreview": {
+        component: lazy(() => import("@/../../packages/components/src/html-elements/docs/aPreview.tsx"))
+    },
+    "html-elements/docs/addressPreview": {
+        component: lazy(() => import("@/../../packages/components/src/html-elements/docs/addressPreview.tsx"))
+    },
+    "html-elements/docs/articlePreview": {
+        component: lazy(() => import("@/../../packages/components/src/html-elements/docs/articlePreview.tsx"))
+    },
+    "html-elements/docs/asidePreview": {
+        component: lazy(() => import("@/../../packages/components/src/html-elements/docs/asidePreview.tsx"))
+    },
+    "html-elements/docs/buttonPreview": {
+        component: lazy(() => import("@/../../packages/components/src/html-elements/docs/buttonPreview.tsx"))
+    },
+    "html-elements/docs/divPreview": {
+        component: lazy(() => import("@/../../packages/components/src/html-elements/docs/divPreview.tsx"))
+    },
+    "html-elements/docs/footerPreview": {
+        component: lazy(() => import("@/../../packages/components/src/html-elements/docs/footerPreview.tsx"))
+    },
+    "html-elements/docs/headerPreview": {
+        component: lazy(() => import("@/../../packages/components/src/html-elements/docs/headerPreview.tsx"))
+    },
+    "html-elements/docs/imgPreview": {
+        component: lazy(() => import("@/../../packages/components/src/html-elements/docs/imgPreview.tsx"))
+    },
+    "html-elements/docs/inputPreview": {
+        component: lazy(() => import("@/../../packages/components/src/html-elements/docs/inputPreview.tsx"))
+    },
+    "html-elements/docs/listPreview": {
+        component: lazy(() => import("@/../../packages/components/src/html-elements/docs/listPreview.tsx"))
+    },
+    "html-elements/docs/mainPreview": {
+        component: lazy(() => import("@/../../packages/components/src/html-elements/docs/mainPreview.tsx"))
+    },
+    "html-elements/docs/navPreview": {
+        component: lazy(() => import("@/../../packages/components/src/html-elements/docs/navPreview.tsx"))
+    },
+    "html-elements/docs/sectionPreview": {
+        component: lazy(() => import("@/../../packages/components/src/html-elements/docs/sectionPreview.tsx"))
+    },
+    "html-elements/docs/spanPreview": {
+        component: lazy(() => import("@/../../packages/components/src/html-elements/docs/spanPreview.tsx"))
+    },
+    "html-elements/docs/tablePreview": {
+        component: lazy(() => import("@/../../packages/components/src/html-elements/docs/tablePreview.tsx"))
+    },
     "icons/docs/icon/preview": {
         component: lazy(() => import("@/../../packages/icons/docs/icon/preview.tsx"))
     },

--- a/packages/components/src/html-elements/docs/aPreview.tsx
+++ b/packages/components/src/html-elements/docs/aPreview.tsx
@@ -1,0 +1,9 @@
+import { A } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <A color="neutral-weak" href="https://www.cc.com/shows/futurama">
+            Futurama
+        </A>
+    );
+}

--- a/packages/components/src/html-elements/docs/addressPreview.tsx
+++ b/packages/components/src/html-elements/docs/addressPreview.tsx
@@ -1,0 +1,11 @@
+import { Address, Link } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <Address color="neutral-weak">
+            <Link href="mailto:media@spacex.com">media@spacex.com</Link>
+            <br />
+            <Link href="tel:+13103636000">(310) 363-6000</Link>
+        </Address>
+    );
+}

--- a/packages/components/src/html-elements/docs/articlePreview.tsx
+++ b/packages/components/src/html-elements/docs/articlePreview.tsx
@@ -1,0 +1,12 @@
+import { Aside, Paragraph } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <Aside color="neutral-weak">
+            <Paragraph>
+                The Universe is under no obligation to make sense to you. The Earth is the cradle of
+                humanity, but mankind cannot stay in the cradle forever.
+            </Paragraph>
+        </Aside>
+    );
+}

--- a/packages/components/src/html-elements/docs/asidePreview.tsx
+++ b/packages/components/src/html-elements/docs/asidePreview.tsx
@@ -1,0 +1,12 @@
+import { Aside, Paragraph } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <Aside color="neutral-weak">
+            <Paragraph>
+                The Universe is under no obligation to make sense to you. The Earth is the cradle of
+                humanity, but mankind cannot stay in the cradle forever.
+            </Paragraph>
+        </Aside>
+    );
+}

--- a/packages/components/src/html-elements/docs/buttonPreview.tsx
+++ b/packages/components/src/html-elements/docs/buttonPreview.tsx
@@ -1,0 +1,9 @@
+import { HtmlButton } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <HtmlButton border="core_rock-900" padding="core_10" type="button">
+            Launch
+        </HtmlButton>
+    );
+}

--- a/packages/components/src/html-elements/docs/divPreview.tsx
+++ b/packages/components/src/html-elements/docs/divPreview.tsx
@@ -1,0 +1,11 @@
+import { Div } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <Div color="neutral-weak">
+            Apple co-founder Steve Wozniak tweeted on Sunday about a "private space company" he's launching
+            that's "unlike the others." Called Privateer Space, its mission is to "keep space safe and
+            accessible to all humankind".
+        </Div>
+    );
+}

--- a/packages/components/src/html-elements/docs/footerPreview.tsx
+++ b/packages/components/src/html-elements/docs/footerPreview.tsx
@@ -1,0 +1,17 @@
+import { Article, H1, HtmlFooter, LI, Paragraph, UL } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <Article>
+            <H1>What does an aerospace engineer do?</H1>
+            <UL>
+                <LI>Research and development</LI>
+                <LI>Testing</LI>
+                <LI>Production and maintenance</LI>
+            </UL>
+            <HtmlFooter color="neutral-weak">
+                <Paragraph>© 2021 Orbiter</Paragraph>
+            </HtmlFooter>
+        </Article>
+    );
+}

--- a/packages/components/src/html-elements/docs/headerPreview.tsx
+++ b/packages/components/src/html-elements/docs/headerPreview.tsx
@@ -1,0 +1,17 @@
+import { H1, Header, Main, Paragraph } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <body>
+            <Header>
+                <H1>Walking On The Moon</H1>
+            </Header>
+            <Main color="neutral-weak">
+                <Paragraph>
+                    Walking on the Moon is classic Sting moment, with his band The Police turning out one of
+                    their most groovy reggae-inspired hits to the background of space exploration.
+                </Paragraph>
+            </Main>
+        </body>
+    );
+}

--- a/packages/components/src/html-elements/docs/imgPreview.tsx
+++ b/packages/components/src/html-elements/docs/imgPreview.tsx
@@ -1,0 +1,7 @@
+import { Img } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <Img border="core_rock-400" src="/frog.jpg" />
+    );
+}

--- a/packages/components/src/html-elements/docs/inputPreview.tsx
+++ b/packages/components/src/html-elements/docs/inputPreview.tsx
@@ -1,0 +1,7 @@
+import { HtmlInput } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <HtmlInput border="core_rock-900" type="text" />
+    );
+}

--- a/packages/components/src/html-elements/docs/listPreview.tsx
+++ b/packages/components/src/html-elements/docs/listPreview.tsx
@@ -1,0 +1,11 @@
+import { LI, UL } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <UL color="neutral-weak">
+            <LI>Explore</LI>
+            <LI>Discover</LI>
+            <LI color="core_sapphire-600">Colonize</LI>
+        </UL>
+    );
+}

--- a/packages/components/src/html-elements/docs/mainPreview.tsx
+++ b/packages/components/src/html-elements/docs/mainPreview.tsx
@@ -1,0 +1,17 @@
+import { H1, Header, Main, Paragraph } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <body>
+            <Header>
+                <H1>Walking On The Moon</H1>
+            </Header>
+            <Main color="neutral-weak">
+                <Paragraph>
+                    Walking on the Moon is classic Sting moment, with his band The Police turning out one of
+                    their most groovy reggae-inspired hits to the background of space exploration.
+                </Paragraph>
+            </Main>
+        </body>
+    );
+}

--- a/packages/components/src/html-elements/docs/navPreview.tsx
+++ b/packages/components/src/html-elements/docs/navPreview.tsx
@@ -1,0 +1,19 @@
+import { LI, Link, Nav, UL } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <Nav color="neutral-weak">
+            <UL>
+                <LI>
+                    <Link href="#">Missions</Link>
+                </LI>
+                <LI>
+                    <Link href="#">Launches</Link>
+                </LI>
+                <LI>
+                    <Link href="#">Careers</Link>
+                </LI>
+            </UL>
+        </Nav>
+    );
+}

--- a/packages/components/src/html-elements/docs/sectionPreview.tsx
+++ b/packages/components/src/html-elements/docs/sectionPreview.tsx
@@ -1,0 +1,16 @@
+import { H1, H2, HtmlSection, Paragraph } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <body>
+            <H1>Blue Origin</H1>
+            <HtmlSection color="neutral-weak">
+                <H2>Our vision</H2>
+                <Paragraph>
+                    Blue Origin was founded by Jeff Bezos with the vision of enabling a future where
+                    millions of people are living and working in space to benefit Earth.
+                </Paragraph>
+            </HtmlSection>
+        </body>
+    );
+}

--- a/packages/components/src/html-elements/docs/spanPreview.tsx
+++ b/packages/components/src/html-elements/docs/spanPreview.tsx
@@ -1,0 +1,11 @@
+import { Span } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <Span color="neutral-weak">
+            NASA is now preparing for an ambitious new era of sustainable human spaceflight and discovery.
+            The agency is building the Space Launch System rocket and the Orion spacecraft for human deep
+            space exploration.
+        </Span>
+    );
+}

--- a/packages/components/src/html-elements/docs/tablePreview.tsx
+++ b/packages/components/src/html-elements/docs/tablePreview.tsx
@@ -1,0 +1,29 @@
+import { Table, TBody, TD, TFoot, TH, THead, TR } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <Table cellPadding={5} color="neutral-weak">
+            <THead fontWeight="core_680">
+                <TR>
+                    <TH textAlign="left">Company</TH>
+                    <TH textAlign="left">Employees</TH>
+                </TR>
+            </THead>
+            <TBody>
+                <TR>
+                    <TD>Space X</TD>
+                    <TD>More than 10 000</TD>
+                </TR>
+                <TR>
+                    <TD>Blue Origin</TD>
+                    <TD>3 500</TD>
+                </TR>
+                <TR color="core_sapphire-600">
+                    <TD>Virgin Galactic</TD>
+                    <TD>823</TD>
+                </TR>
+            </TBody>
+            <TFoot></TFoot>
+        </Table>
+    );
+}


### PR DESCRIPTION
Document HTML elements

There's no PropTable available in @hopper-ui/components, i was thinking about using `Content`, but unsure.