### PR TITLE
SGPD-8991: fix: Correct pointerdown event listener name

### DIFF
--- a/.changeset/curly-showers-travel.md
+++ b/.changeset/curly-showers-travel.md
@@ -1,0 +1,5 @@
+---
+"@hopper-ui/components": patch
+---
+
+Correct pointerdown event listener name

--- a/packages/components/src/tooltip/src/TooltipTrigger.tsx
+++ b/packages/components/src/tooltip/src/TooltipTrigger.tsx
@@ -179,7 +179,7 @@ function useForwardFocusablePropsToRef({ disabled = false, triggerRef }: UseForw
         const element = triggerRef.current;
         element.addEventListener("pointerenter", onPointerEnter);
         element.addEventListener("pointerleave", onPointerLeave);
-        element.addEventListener("pointerdown ", onPointerDown);
+        element.addEventListener("pointerdown", onPointerDown);
         element.addEventListener("focusin", onFocus);
         element.addEventListener("focusout", onBlur);
         element.addEventListener("keydown", onKeyDown);
@@ -188,7 +188,7 @@ function useForwardFocusablePropsToRef({ disabled = false, triggerRef }: UseForw
         return () => {
             element.removeEventListener("pointerenter", onPointerEnter);
             element.removeEventListener("pointerleave", onPointerLeave);
-            element.removeEventListener("pointerdown ", onPointerDown);
+            element.removeEventListener("pointerdown", onPointerDown);
             element.removeEventListener("focusin", onFocus);
             element.removeEventListener("focusout", onBlur);
             element.removeEventListener("keydown", onKeyDown);


### PR DESCRIPTION
## Summary
- The `pointerdown` listener was registered/removed with a trailing space (`"pointerdown "`), so the handler never actually bound to the real event, breaking pointer-down behavior on tooltip triggers.
- Fixed the typo in both `addEventListener` and `removeEventListener` calls in `TooltipTrigger.tsx`.

## Test plan
- [ ] Verify tooltip trigger responds correctly to pointer down interactions