### PR TITLE
[SGPD-9027] Replace tsx with native Node execution for build scripts

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -17,9 +17,9 @@
         "copy:ai-docs-to-public": "shx rm -rf public/ai-docs && mkdir -p public/ai-docs && shx cp -r dist/ai-docs public",
         "build:ai-docs": "tsx --tsconfig ./scripts/ai-utils/tsconfig.json scripts/buildAiDocs.ts && pnpm copy:ai-docs-to-public",
         "generate": "pnpm run \"/^generate:.*/\"",
-        "generate:componentData": "tsx scripts/generateComponentData.ts",
-        "generate:previewRef": "tsx scripts/generatePreviewRef.ts",
-        "copy:images": "tsx scripts/copyImages.ts"
+        "generate:componentData": "node scripts/generateComponentData.ts",
+        "generate:previewRef": "node scripts/generatePreviewRef.ts",
+        "copy:images": "node scripts/copyImages.ts"
     },
     "dependencies": {
         "@tanstack/react-table": "^8.20.5",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -38,7 +38,7 @@
         "stylelint": "stylelint \"**/*.css\" --config ../../.stylelintrc.js --allow-empty-input --cache --cache-location node_modules/.cache/stylelint --max-warnings=0",
         "typecheck": "tsc",
         "test": "vitest run",
-        "find-types": "tsx scripts/findImportedTypes.ts"
+        "find-types": "node scripts/findImportedTypes.ts"
     },
     "dependencies": {
         "@hopper-ui/icons": "*",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -34,7 +34,7 @@
     },
     "scripts": {
         "build": "tsup --config ./tsup.build.ts",
-        "generate-icons": "tsx scripts/build.ts",
+        "generate-icons": "node scripts/build.ts",
         "stylelint": "stylelint \"**/*.css\" --config ../../.stylelintrc.js --allow-empty-input --cache --cache-location node_modules/.cache/stylelint --max-warnings=0",
         "typecheck": "tsc",
         "test": "vitest run"
@@ -63,7 +63,6 @@
         "svgo": "4.0.0",
         "ts-node": "10.9.2",
         "tsup": "8.5.0",
-        "tsx": "4.20.6",
         "typescript": "5.5.4"
     },
     "peerDependencies": {

--- a/packages/svg-icons/package.json
+++ b/packages/svg-icons/package.json
@@ -31,10 +31,10 @@
     "scripts": {
         "build": "pnpm run \"/^build:.*/\"",
         "build:icons": "copyfiles --flat src/optimized-icons/* dist/icons",
-        "build:inline-icons": "tsx scripts/buildInlineIcons.ts",
+        "build:inline-icons": "node scripts/buildInlineIcons.ts",
         "build:rich-icons": "copyfiles --flat src/optimized-rich-icons/* dist/rich-icons",
-        "build:metadata": "tsx scripts/buildIconsMetadata.ts",
-        "generate-icons": "tsx scripts/generate.ts",
+        "build:metadata": "node scripts/buildIconsMetadata.ts",
+        "generate-icons": "node scripts/generate.ts",
         "typecheck": "tsc",
         "test": "vitest run"
     },
@@ -45,7 +45,6 @@
         "hast-util-select": "6.0.4",
         "rehype-parse": "9.0.1",
         "svgo": "4.0.0",
-        "tsx": "4.20.6",
         "typescript": "5.5.4",
         "unified": "11.0.5"
     }

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -29,7 +29,7 @@
     },
     "scripts": {
         "clean:dist": "pnpm dlx rimraf dist",
-        "build": "tsx src/style-dictionary/build.ts",
+        "build": "node src/style-dictionary/build.ts",
         "typecheck": "tsc",
         "test": "vitest run"
     },
@@ -39,7 +39,6 @@
         "@workleap/typescript-configs": "3.0.4",
         "style-dictionary": "5.5.0",
         "style-dictionary-utils": "6.0.1",
-        "tsx": "4.20.6",
         "typescript": "5.5.4"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -571,9 +571,6 @@ importers:
       tsup:
         specifier: 8.5.0
         version: 8.5.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.26)(tsx@4.20.6)(typescript@5.5.4)(yaml@2.8.1)
-      tsx:
-        specifier: 4.20.6
-        version: 4.20.6
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -656,9 +653,6 @@ importers:
       svgo:
         specifier: 4.0.0
         version: 4.0.0
-      tsx:
-        specifier: 4.20.6
-        version: 4.20.6
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -683,9 +677,6 @@ importers:
       style-dictionary-utils:
         specifier: 6.0.1
         version: 6.0.1(style-dictionary@5.5.0)
-      tsx:
-        specifier: 4.20.6
-        version: 4.20.6
       typescript:
         specifier: 5.5.4
         version: 5.5.4


### PR DESCRIPTION
## Description

Node 24 (this repo's floor, per `.nvmrc`) natively strips TypeScript types, so `tsx` is no longer needed to run plain `.ts` build scripts. This swaps `tsx X.ts` for `node X.ts` in the scripts that already use explicit relative `.ts` imports with no JSX and no tsconfig path aliases, and drops the now-unused `tsx` devDependency from the packages that only used it for these scripts.

- `packages/components`: `find-types`
- `packages/icons`: `generate-icons`
- `packages/tokens`: `build`
- `packages/svg-icons`: `build:inline-icons`, `build:metadata`, `generate-icons`
- `apps/docs`: `generate:componentData`, `generate:previewRef`, `copy:images`

`tsx` remains for `apps/docs` `build:ai-docs` (JSX + `@/` path aliases) and `apps/mcp-server` `dev:server:expressJs` (extensionless bundler-style imports) — out of scope for this change.

## Testing

Ran each of the 9 migrated scripts under both `tsx` and `node` and diffed the results: identical stdout and byte-identical output artifacts (generated components, metadata JSON, inline icon bundles, style-dictionary build output, docs component data) for every script, exit code 0 on both.
