### PR TITLE
SGPD-9020: Add ActionBar component

### DIFF
--- a/.changeset/quiet-otters-dance.md
+++ b/.changeset/quiet-otters-dance.md
@@ -1,0 +1,8 @@
+---
+"@hopper-ui/tokens": patch
+"@hopper-ui/styled-system": patch
+"@hopper-ui/components": minor
+---
+
+feat(ActionBar): add ActionBar component, ported from React Spectrum S2
+- Add `--hop-comp-action-bar-*` tokens to both brands

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.0.1",
+    "configurations": [
+        {
+            "name": "storybook",
+            "runtimeExecutable": "pnpm",
+            "runtimeArgs": ["storybook"],
+            "port": 6006
+        },
+        {
+            "name": "docs",
+            "runtimeExecutable": "pnpm",
+            "runtimeArgs": ["--filter", "docs", "dev"],
+            "port": 3000
+        }
+    ]
+}

--- a/.claude/skills/_port-component/SKILL.md
+++ b/.claude/skills/_port-component/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: port-component
+description: Port a new component into the Workleap Hopper design system (wl-hopper repo) from its React Spectrum S2 implementation. Use whenever the user wants to add, create, build, scaffold, or implement a brand-new Hopper component — especially when they name a React Spectrum / React Aria component to base it on. Trigger on phrasings like "port ActionBar from S2", "add a new Hopper component for X", "implement the RAC Toolbar in Hopper", "build a Hopper version of Tree", "we need a X component, base it on react-spectrum", or any request naming an Adobe React Spectrum / react-aria-components component that doesn't exist yet under packages/components/src/. Trigger on the name the user happens to use, whether that's Hopper's intended name or S2's/RAC's — these frequently differ (Hopper Divider is RAC Separator, Hopper Accordion is RAC DisclosureGroup, Hopper Callout is S2 InlineAlert), and the skill resolves the mapping itself. Not for editing or extending a component that already exists in Hopper — this skill is for brand-new components only.
+---
+
+# Port a component from React Spectrum S2 into Hopper
+
+You are porting a component from Adobe's [React Spectrum S2](https://github.com/adobe/react-spectrum/tree/main/packages/%40react-spectrum/s2) into the Hopper design system (`wl-hopper` monorepo). S2 is always the reference implementation, even for components that also exist in plain `react-aria-components` — S2 is what a designer means when they name a component, and it's usually a more complete API than the bare RAC primitive. Your job is to reproduce the component's behavior and API shape using Hopper's own conventions: `useStyledSystem`, CSS modules, DTCG tokens, and the docs/stories/tests structure every other Hopper component follows.
+
+This is a long job. Work through it **phase by phase, stopping for the user's review after each phase** — don't barrel through to a finished PR in one shot.
+
+## Phase 0 — Guard: is this actually a new component?
+
+Before anything else:
+
+```bash
+ls packages/components/src/ | grep -i "<kebab-name>"
+grep -i "<PascalName>" packages/components/src/index.ts
+```
+
+If a directory or export already exists, **stop** and tell the user this skill only handles brand-new components — extending an existing one is a different job.
+
+**A name miss is not proof of absence.** Because Hopper names diverge from S2/RAC (see Phase 1), the component may already exist under a different name — Hopper's `Divider` would not be found by grepping for RAC's `Separator`. So when the user names an S2/RAC component and the grep comes back empty, also check whether an existing Hopper component already *wraps* that primitive:
+
+```bash
+grep -rn "<RACPrimitiveName>" packages/components/src/*/src/*.tsx
+```
+
+If something already wraps it, stop and tell the user what you found rather than building a duplicate under a second name.
+
+## Phase 1 — Research the S2 reference
+
+### First: resolve the name
+
+**Hopper's name for a component often differs from S2's and RAC's, and S2's often differs from RAC's.** Hopper tends to name by *purpose*, RAC by *mechanism*. Real examples in this repo:
+
+| Hopper | RAC / S2 primitive it's built on |
+|---|---|
+| `Divider` | RAC `Separator` |
+| `Accordion` | RAC `DisclosureGroup` |
+| `SegmentedControl` | RAC `ToggleButtonGroup` |
+| `Alert` | RAC `Dialog` + `DialogTrigger` |
+| `ErrorMessage`, `HelperMessage` | RAC `FieldError` |
+| `Callout` | S2 `InlineAlert` |
+| `Select` | S2 `Picker` → RAC `Select` |
+
+So there are up to **three** names in play, and a name that doesn't resolve means nothing about whether the component exists. Never conclude "S2 doesn't have this" from a failed fetch of a guessed name.
+
+Resolve it before fetching anything:
+
+1. **Try the literal name** the user gave, at both the S2 and RAC paths.
+2. **If that misses, search rather than guess.** List the S2 source directory and the vendored RAC references to see the real inventory — both are cheap:
+   ```bash
+   ls .claude/skills/react-aria/references/components/
+   ```
+   plus a WebFetch of `https://github.com/adobe/react-spectrum/tree/main/packages/%40react-spectrum/s2/src` for the S2 file list.
+3. **Match on behavior and anatomy, not on the name** — what it renders, what states it has, what it's for. A Hopper "Callout" and an S2 "InlineAlert" are the same component wearing different labels.
+4. **State the mapping explicitly** and carry it into Phase 2's proposal: *"Hopper `X` ← S2 `Y` ← RAC `Z`."* If you can't confidently resolve it, ask the user which S2/RAC component they have in mind rather than porting the wrong thing.
+
+Once resolved, the **Hopper name governs everything on the Hopper side** — directory, component name, `GlobalXCssSelector`, CSS classes, token namespace, docs page, story title. The S2/RAC name appears only in two places: the URLs you fetch, and the `as RACX` import aliases in the implementation.
+
+### Then: gather the sources
+
+Layer the sources — each is optional, but do them in this order:
+
+1. **S2 source (required).** WebFetch the real implementation, using the **S2 name** resolved above (not the Hopper name). This is the only place it lives:
+   ```
+   https://raw.githubusercontent.com/adobe/react-spectrum/main/packages/@react-spectrum/s2/src/<S2Name>.tsx
+   ```
+   Also fetch its sibling `stories/<S2Name>.stories.tsx` and any `docs/<S2Name>.mdx` in the same S2 package — they reveal the intended anatomy and states. If the fetch 404s, go back to the name-resolution steps before concluding anything; if the network itself fails, tell the user and ask them to paste the source rather than guessing at the API.
+
+2. **RAC primitive reference (use it).** The `react-aria` skill ships 94 component references at `.claude/skills/react-aria/references/components/<Primitive>.md`, checked into this repo — no network needed. Read the one(s) matching what S2 wraps (e.g. ActionBar wraps Toolbar; ComboBox wraps a Popover + ListBox). This is your source for render props, `data-*` attributes, and keyboard/a11y behavior.
+
+3. **Exact prop types (bonus, best-effort).** If `node_modules/react-aria-components` is present (pinned at `1.13.0` in `packages/components/package.json`), read its `.d.ts` for exact prop signatures. Skip silently if absent — never block on this layer.
+
+Trace the full dependency chain — note every RAC primitive and every sub-component S2 pulls in (e.g. ActionBar → Toolbar, entry/exit animations, collection rendering). Report this chain to the user before moving on.
+
+## Phase 2 — Propose the Hopper API, then get the visual spec → **stop here for review**
+
+Present, in plain terms:
+
+- **The name mapping** — *"Hopper `X` ← S2 `Y` ← RAC `Z`"* — and, when the Hopper name is yours to choose rather than given, the name you propose and why. Hopper names by purpose; prefer the word a designer would use over the mechanism RAC exposes. Get this confirmed before building: the name is baked into the directory, CSS classes, token namespace, and the public export, so renaming later touches every file.
+- The proposed `<X>Props` surface, mapped against S2's props (what's kept, renamed, or dropped and why).
+- Sub-components and slots (e.g. `Tag` + `TagGroup`, or `Avatar` + `AvatarGroup`).
+- Sizes and variants, if S2 has them — but note that Hopper's actual scale, spacing, and colors cannot come from S2, since S2 uses Spectrum's design language, not Hopper's.
+- Which docs `section` (directory under `apps/docs/content/components/`) and which `category` (frontmatter value) it belongs to — see `references/docs-stories-tests.md` for the list; these are two different axes and often don't match (e.g. `Tag.mdx` lives in `status/` but declares `category: "collections"`).
+
+Then **ask the user for the visual spec** — a Figma link, or a description of sizes/variants/states/spacing — and wait for it. Do not invent colors, spacing, or sizing values; S2 cannot supply them and guessing produces tokens that need to be redone.
+
+Do not proceed to Phase 3 until the user has responded to both the API proposal and the visual-spec request.
+
+## Phase 3 — Build source, CSS, and tokens → **stop here for review**
+
+Read `references/file-layout.md` for where every file goes, `references/component-anatomy.md` for the exact `.tsx` patterns (the `useContextProps` → `useStyledSystem` → `cssModule` chain, props conventions, exports), and `references/css-and-tokens.md` for the CSS module conventions.
+
+For component tokens specifically: **invoke the `_update-tokens` skill** rather than hand-rolling the DTCG JSON yourself — it already owns the token format, brand-symmetry rules (Workleap + ShareGate), and the token changeset. Feed it the visual spec from Phase 2.
+
+Build everything in Phase 3 as one unit — don't stage another checkpoint mid-phase, even for a large port like ActionBar. Present the finished `.tsx` / `.module.css` / token diffs together.
+
+## Phase 4 — Docs, stories, tests, i18n, changeset → **stop here for review**
+
+Read `references/docs-stories-tests.md` in full and follow it for:
+
+- The MDX docs page under `apps/docs/content/components/<section>/<PascalName>.mdx`
+- Storybook chromatic stories under `tests/chromatic/<PascalName>.stories.tsx`
+- Vitest unit + SSR tests under `tests/vitest/`
+- i18n strings in **both** `packages/components/src/i18n/intl/en-US.json` and `fr-CA.json` if the component needs any localized strings (aria-labels, warnings, etc.)
+- A changeset in `.changeset/`
+
+## Phase 5 — Verify
+
+Run, in this order, and fix anything that fails before reporting done:
+
+```bash
+pnpm doc:generate      # regenerates apps/docs/examples/Preview.ts and apps/docs/datas/ — gitignored, don't commit
+pnpm lint              # turbo: eslint, stylelint, typecheck, syncpack
+pnpm test              # vitest
+pnpm build:tokens      # only if token files changed
+```
+
+Then a visual pass:
+
+- Launch Storybook (`pnpm storybook`) and actually look at the new stories in the browser, in both light and dark, both brands. Report what you saw, not just that it built.
+- Run the axe accessibility check locally, per `contributing/components.md`: `pnpm storybook-nolazy` in one terminal, `pnpm test-storybook` in another. This is local-only and not part of CI.
+
+Report the outcome of each check plainly. Don't claim the component "works" from lint/tsc alone — say explicitly whether you visually verified it.
+
+## Pitfalls to actively prevent
+
+- **Concluding a component doesn't exist because the name didn't match** — in either direction. A 404 on the S2 URL usually means the S2 name differs, not that S2 lacks the component; an empty grep of `packages/components/src/` doesn't rule out an existing Hopper component wrapping the same primitive under another name.
+- **Letting the S2/RAC name leak onto the Hopper side** — the directory, `GlobalXCssSelector`, CSS classes, `comp-<name>` token namespace, docs filename, and story title all use the *Hopper* name. The S2/RAC name belongs only in fetch URLs and `as RAC<Primitive>` import aliases.
+- **Forgetting `pnpm doc:generate`** — `<PropTable>` and `<Example>` on the docs page render empty with no build error.
+- **Multiple components in one `export` statement** (e.g. `export { _ComboBox as ComboBox, ListBoxItem as ComboBoxItem }`) — `react-docgen-typescript` cross-wires props from one component onto another in the generated docs table. Always assign and export separately; see `contributing/components.md`.
+- **Tokens added to only one brand** — Workleap-only tokens leave ShareGate falling back to unstyled or wrong values. `_update-tokens` defaults to both; don't override that without the user explicitly scoping it.
+- **Borrowing another component's `--hop-comp-<other>-*` token** instead of defining one in this component's own token file — breaks encapsulation (see repo `CLAUDE.md`).
+- **Style properties (`fontWeight`, `color`, etc.) set directly in a `SlotProvider`/context object** instead of in the CSS module — see repo `CLAUDE.md`.
+- **Hand-writing `:hover`/`:focus` CSS** instead of RAC's `[data-hovered]`/`[data-focus-visible]` attribute selectors — misses keyboard-vs-pointer distinctions RAC already handles.
+- **Committing gitignored generated output** — `apps/docs/datas/` and `apps/docs/examples/Preview.ts` are regenerated by `pnpm doc:generate`; don't `git add` them.
+- **Adding a `## Migration Notes` section with no Orbiter predecessor** — only add it if an equivalent Orbiter component actually existed; several current Hopper components correctly omit this section entirely.
+- **Skipping the visual-spec gate** — proceeding to CSS/tokens without an explicit spec from the user produces values that have to be redone later.
+
+## References
+
+- `references/file-layout.md` — directory/file structure a new component needs, and every registry file that must be updated
+- `references/component-anatomy.md` — the `.tsx` implementation patterns: props, the styled-system chain, className/style composition, context, exports
+- `references/css-and-tokens.md` — CSS module selector conventions, two-tier CSS variables, RAC data-attribute states, and how the token step defers to `_update-tokens`
+- `references/docs-stories-tests.md` — MDX docs page frontmatter and section order, Storybook story shape, vitest test shape, changeset format

--- a/.claude/skills/_port-component/references/component-anatomy.md
+++ b/.claude/skills/_port-component/references/component-anatomy.md
@@ -1,0 +1,205 @@
+# Component `.tsx` anatomy
+
+Distilled from `packages/components/src/tag/src/Tag.tsx` and `packages/components/src/segmented-control/src/SegmentedControl.tsx` — read both end-to-end before writing a new component if anything below is unclear.
+
+## Import grouping and ordering
+
+Top to bottom, with a blank line between groups:
+
+1. `@hopper-ui/*` (styled-system, icons)
+2. `@react-aria/*`, `@react-stately/*`, `@react-types/*`, `react-aria`, `react-aria-components`
+3. Third-party (`clsx`, etc.)
+4. `react` itself
+5. Other Hopper components, via relative `../../<component>/index.ts` (never deep-import into another component's `src/`)
+6. Sibling files in the same component (`./XContext.ts`, `./X.utils.ts`)
+7. `styles from "./X.module.css"` — always last
+
+```tsx
+import { IconContext } from "@hopper-ui/icons";
+import { type StyledComponentProps, useStyledSystem } from "@hopper-ui/styled-system";
+import { filterDOMProps, mergeProps } from "@react-aria/utils";
+import clsx from "clsx";
+import { forwardRef, type ForwardedRef } from "react";
+import { composeRenderProps, useContextProps } from "react-aria-components";
+
+import { AvatarContext } from "../../avatar/index.ts";
+import { cssModule } from "../../utils/index.ts";
+
+import { XContext } from "./XContext.ts";
+
+import styles from "./X.module.css";
+```
+
+## Aliasing the RAC primitive when names diverge
+
+Hopper's component name frequently differs from the RAC primitive it wraps (`Divider` wraps `Separator`, `Accordion` wraps `DisclosureGroup`, `SegmentedControl` wraps `ToggleButtonGroup`). The convention is to alias the primitive with a `RAC` prefix on import, so the file reads in Hopper's vocabulary while making the underlying primitive explicit:
+
+```tsx
+import { Separator as RACSeparator, type SeparatorProps as RACSeparatorProps, useContextProps } from "react-aria-components";
+
+export interface DividerProps extends StyledComponentProps<RACSeparatorProps> {}
+// ...
+return <RACSeparator ref={ref} className={classNames} {...otherProps} />;
+```
+
+Alias **both** the component and its props type, always as `RAC<PrimitiveName>` — keep the primitive's own name in the alias (`RACSeparator`, not `RACDivider`), so a reader can trace it back to RAC's docs. Everything else in the file — the interface name, `GlobalXCssSelector`, CSS classes, the exported name — uses the Hopper name.
+
+When the primitive's name happens to match Hopper's, the alias is still used for the wrapped element to keep the local name free for the exported component (`Tag as RACTag`, `Tooltip as RACTooltip`).
+
+## `GlobalXCssSelector`
+
+Every component exports a top-level unique selector constant, per `contributing/components.md`:
+
+```tsx
+export const GlobalTagCssSelector = "hop-Tag";
+```
+
+Used both as a stable global-CSS hook and as the first argument passed into the className composition helper.
+
+## Props interface
+
+```tsx
+export interface XProps extends StyledComponentProps<RACXProps> {
+    /**
+     * <what this does>
+     * @default "<value>"   // only when there's a default
+     */
+    someProp?: SomeType;
+}
+```
+
+- Extend `StyledComponentProps<RACXProps>` when wrapping a RAC component (gets you the style-prop system layered onto the real RAC props).
+- Extend `StyledComponentProps<BaseComponentDOMProps>` when the component renders its own DOM element with no RAC counterpart (see `SegmentedControlProps`).
+- JSDoc every prop. Document the default with `@default` when one exists in the implementation — this is what feeds the generated props table (`react-docgen-typescript`), so the comment is the only source of truth a consumer sees.
+- Size props are typically `ResponsiveProp<XSize>` from `@hopper-ui/styled-system`, not a bare union — this is what makes `size={{ base: "sm", md: "lg" }}` work.
+
+## The function body chain
+
+In this order, every time:
+
+```tsx
+function X(props: XProps, ref: ForwardedRef<HTMLDivElement>) {
+    [props, ref] = useContextProps(props, ref, XContext);
+    // useFormProps(props) here too, only if the component can live inside a Form
+    const { stylingProps, ...ownProps } = useStyledSystem(props);
+    const {
+        className,
+        children: childrenProp,
+        style: styleProp,
+        size: sizeProp,
+        variant = "neutral",   // defaults destructured here, not as a props default
+        ...otherProps
+    } = ownProps;
+
+    const size = useResponsiveValue(sizeProp) ?? "md";
+    // ...
+}
+```
+
+1. **`useContextProps(props, ref, XContext)`** — always first. Merges slot-provided props/ref from an ancestor `<XContext.Provider>` or `SlotProvider`. Use the two-arg form `useContextProps(props, ref, XContext)` unless the component has a default slot name, in which case pass `{ ...props, slot: props.slot || DefaultXSlot }`.
+2. **`useFormProps`** — only for form-field-like components; merges ambient `<Form>` styling props (see `Tag`'s `useFormProps(props as FormStyleProps)`).
+3. **`useStyledSystem(props)`** — strips the style-system props (`marginTop`, `padding`, etc.) into `stylingProps`, leaving `ownProps` with the component's actual props plus DOM passthrough props.
+4. **Destructure `ownProps`** to pull out what the component needs; leave the rest in `...otherProps` for DOM passthrough.
+5. **`useResponsiveValue(sizeProp) ?? "<default>"`** resolves a `ResponsiveProp<T>` down to the size for the current breakpoint.
+
+## className composition
+
+```tsx
+const classNames = composeClassnameRenderProps(
+    className,
+    GlobalXCssSelector,
+    cssModule(styles, "hop-X", size, variant),
+    stylingProps.className
+);
+```
+
+- `composeClassnameRenderProps` (from `../../utils/index.ts`) when the component's `children`/`className` can be a RAC render-prop function; plain `clsx(...)` when they can't (see `contributing/components.md`'s example, which predates the render-props helper but shows the same ordering).
+- **Order matters**: user-supplied `className` first, then the global selector, then the composed modifier classes, then `stylingProps.className` last so style-system utility classes always win.
+- `cssModule(styles, "hop-X", size, variant, isSomething && "modifier-name")` — falsy values are dropped, so conditional modifiers are just `condition && "name"`.
+
+## style composition
+
+```tsx
+const style = composeRenderProps(styleProp, prev => ({
+    ...stylingProps.style,
+    ...prev
+}));
+```
+
+`stylingProps.style` (computed from style-system props) goes first, the caller's own inline `style` (render-prop result `prev`) wins — so an explicit `style={{ marginBottom: "13px" }}` prop always overrides a style-system-derived value.
+
+## Context file
+
+One per component (and per sub-component), in its own file:
+
+```tsx
+// XContext.ts
+import { createContext } from "react";
+import type { ContextValue } from "react-aria-components";
+
+import type { XProps } from "./X.tsx";
+
+export const XContext = createContext<ContextValue<XProps, HTMLDivElement>>({});
+
+XContext.displayName = "XContext";
+```
+
+## Slot styling — never inline style properties in context objects
+
+Per repo `CLAUDE.md`: when a component passes styling down to a child via `SlotProvider`, only pass `className` (pointing at a CSS module class), never `fontWeight`, `color`, or other visual properties directly:
+
+```tsx
+// ✅ correct
+[TextContext, { className: styles["hop-Tag__text"], size: TagToTextSizeAdapter[size] }]
+
+// ❌ wrong — visual property set in a context object
+[HeadingContext, { fontWeight: "heading-xs-medium" }]
+```
+
+Define the font weight (or any other visual property) in the CSS module and reference it through `className` instead.
+
+Reuse existing utilities from `packages/components/src/utils/index.ts` rather than reimplementing them: `cssModule`, `composeClassnameRenderProps`, `SlotProvider`, `ClearContainerSlots`, `ensureTextWrapper`, `useRenderProps`, `SizeAdapter`. A `SizeAdapter<XSize, YSize>` is the established pattern for mapping one component's size scale onto a nested component's scale (e.g. `TagToAvatarSizeAdapter`).
+
+## Export tail and display name
+
+```tsx
+/**
+ * <One-sentence description of what the component is/does.>
+ *
+ * [View Documentation](https://hopper.workleap.design/components/X)
+ */
+const _X = forwardRef<HTMLDivElement, XProps>(X);
+_X.displayName = "X";
+
+export { _X as X };
+```
+
+- Internal name is prefixed with `_` (`_X`), re-exported under the real name (`X`) — this is what lets `react-docgen-typescript`'s `componentNameResolver` in `apps/docs/scripts/generateComponentData.ts` strip the underscore for the public docs.
+- Wrap in `slot("<slot-name>", forwardRef(...))` from `@hopper-ui/styled-system` instead of bare `forwardRef` when the component is meant to be used as a named slot inside another component (see `Tag`'s `slotFn("tag", ...)`).
+- The JSDoc block above the export is what shows up as the component description in generated docs — write it as the one-sentence summary you'd want on the docs page, and always include the `[View Documentation](https://hopper.workleap.design/components/<PascalName>)` link.
+
+## The export gotcha (`contributing/components.md`)
+
+**Never export more than one component in a single export statement.** `react-docgen-typescript` misattributes props when it sees `export { _A as A, B as C }` in one statement — props from `B` can get attached to `A` in the generated docs table.
+
+```tsx
+// ❌ incorrect — props get cross-wired in docs
+export { _ComboBox as ComboBox, ListBoxItem as ComboBoxItem };
+
+// ✅ correct — separate statements
+export const ComboBoxItem = ListBoxItem;
+export const ComboBoxSection = ListBoxSection;
+export { _ComboBox as ComboBox };
+```
+
+## i18n
+
+If the component needs any user-facing string that isn't caller-supplied (an `aria-label`, a console warning, etc.):
+
+```tsx
+const stringFormatter = useLocalizedString();
+stringFormatter.format("X.someKey");
+stringFormatter.format("X.someKey", { value });
+```
+
+Add the key to **both** `packages/components/src/i18n/intl/en-US.json` and `packages/components/src/i18n/intl/fr-CA.json` — all strings currently live in these two flat files (not split per component), so add your key alongside the existing ones rather than creating a new file.

--- a/.claude/skills/_port-component/references/component-anatomy.md
+++ b/.claude/skills/_port-component/references/component-anatomy.md
@@ -128,6 +128,36 @@ const style = composeRenderProps(styleProp, prev => ({
 
 `stylingProps.style` (computed from style-system props) goes first, the caller's own inline `style` (render-prop result `prev`) wins — so an explicit `style={{ marginBottom: "13px" }}` prop always overrides a style-system-derived value.
 
+## Composing handlers the component also needs internally
+
+When the component listens for its own DOM event (e.g. `Escape` via `useKeyboard`) *and* spreads `...otherProps` (which may carry a consumer-supplied handler for that same event), compose both instead of letting one clobber the other — and destructure the consumer's handler out by name first so it isn't silently dropped into `otherProps`:
+
+```tsx
+const {
+    onKeyDown,
+    ...otherProps
+} = ownProps;
+
+const { keyboardProps } = useKeyboard({
+    onKeyDown: event => {
+        if (event.key === "Escape") {
+            onClearSelection?.();
+        } else {
+            event.continuePropagation();
+        }
+    }
+});
+
+const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    onKeyDown?.(event);
+    keyboardProps.onKeyDown?.(event);
+};
+
+return <div {...otherProps} onKeyDown={handleKeyDown} />;
+```
+
+Whichever handler prop is spread or assigned **last wins** — this applies to `style`/`className` too (see above), not just event handlers. Before shipping, check every prop the component destructures out of `ownProps` for a matching one spread back in via `...otherProps`/`...stylingProps`, and verify the later one in JSX source order is the one you actually intend to win.
+
 ## Context file
 
 One per component (and per sub-component), in its own file:

--- a/.claude/skills/_port-component/references/css-and-tokens.md
+++ b/.claude/skills/_port-component/references/css-and-tokens.md
@@ -1,0 +1,75 @@
+# CSS module and token conventions
+
+## Selector naming (`contributing/components.md`)
+
+BEM-like, with a fixed namespace and the React component name:
+
+```
+.hop-X                          base
+.hop-X--modifier-name           modifier (variant, size, state class)
+.hop-X__descendant-name         a descendant element
+.hop-X__descendant-name--modifier-name
+```
+
+`cssModule(styles, "hop-X", size, variant, isStandalone && "standalone")` (from `../../utils/index.ts`) composes these for you from the base + a list of modifier name fragments — falsy entries are dropped. The modifier names passed in must exactly match the `--modifier` suffixes defined in the CSS file (e.g. passing `"sm"` requires a `.hop-X--sm` rule to exist).
+
+## Two-tier CSS variables
+
+Every component's `.module.css` declares its own **local** `--hop-X-*` variables at the top, inside the base `.hop-X` rule, each pointing at either a component token (`--hop-comp-x-*`) or a semantic token (`--hop-neutral-*`, `--hop-status-*`, etc.). Group them with comments by concern:
+
+```css
+.hop-Tag {
+    /* Default */
+    --hop-Tag-border-size: 0.0625rem;
+    --hop-Tag-border-radius: var(--hop-comp-tag-border-radius);
+
+    /* Typography */
+    --hop-Tag-font-family: var(--hop-comp-tag-text-font);
+
+    /* Small */
+    --hop-Tag-sm-block-size: 1.25rem;
+    --hop-Tag-sm-padding-inline: var(--hop-space-inset-sm);
+
+    /* Neutral */
+    --hop-Tag-neutral-border-color: var(--hop-comp-tag-border-color);
+    --hop-Tag-neutral-background-color: var(--hop-comp-tag-background-color);
+
+    /* Focus */
+    --hop-Tag-focus-ring-color: var(--hop-comp-tag-border-color-focus);
+}
+```
+
+Rules further down the file consume only the **local** `--hop-X-*` aliases, never the raw token directly — this indirection is what makes it possible to see every value a component depends on in one place at the top of the file, and is why the two rules below matter.
+
+**Two hard rules (repo `CLAUDE.md`), both actively enforced in review:**
+
+1. **No hardcoded values.** Every color, spacing, radius, or typography value must be `var(--hop-*)` — no literal hex codes, no bare `px`/`rem` for anything that has a token equivalent (raw geometry like `0.0625rem` for a hairline border, or component-specific one-off pixel values with no token equivalent, are the accepted exception — see `--hop-Tag-sm-block-size` above).
+2. **Never reference another component's token.** `--hop-comp-<other-component>-*` must only appear inside that other component's own `.module.css`. If a similar visual treatment is needed here, add a **new** token to this component's own `<name>.tokens.json` — don't borrow. Example: don't put `var(--hop-comp-tooltip-color)` inside `X.module.css`; add `--hop-comp-x-description-color` to `x.tokens.json` instead.
+
+## State selectors — always RAC data attributes, never pseudo-classes
+
+RAC components expose interaction state as `data-*` attributes on the rendered element (`[data-hovered]`, `[data-pressed]`, `[data-focus-visible]`, `[data-disabled]`, `[data-selected]`, `[data-invalid]`) rather than relying on native `:hover`/`:focus`. Style against these, combined with the BEM modifier class for the variant/size they apply to:
+
+```css
+.hop-Tag--neutral[data-focus-visible] { /* ... */ }
+.hop-Tag--neutral:not(.hop-Tag--standalone)[data-hovered] { /* ... */ }
+.hop-Tag--neutral[data-pressed] { /* ... */ }
+.hop-Tag--neutral[data-disabled] { /* ... */ }
+```
+
+Using native `:hover`/`:focus` instead misses RAC's pointer-vs-keyboard distinction (`data-focus-visible` only fires for keyboard focus) and won't reflect `isDisabled`/`isPressed` state managed by React state rather than the DOM.
+
+Check the RAC reference for the primitive (`.claude/skills/react-aria/references/components/<Primitive>.md`) for the exact list of `data-*` attributes and render-prop values it exposes — don't guess which ones exist.
+
+## Component tokens — delegate, don't hand-roll
+
+Component token files live at `packages/tokens/src/tokens/components/{workleap,sharegate}/<kebab-name>.tokens.json`, DTCG-shaped (`$type`/`$value`, Style Dictionary v5), namespaced under a top-level `comp-<component-name>` key, referencing semantic tokens by preference (`{neutral.surface}`) so they adapt between light and dark automatically.
+
+**Don't write these files directly.** Invoke the **`_update-tokens`** skill for this step — it already owns:
+
+- the DTCG format and the exact `$type` vocabulary this repo uses
+- reference syntax (`{path.to.token}`, dot vs. dash rules)
+- brand symmetry (Workleap + ShareGate, both get the token by default)
+- the token changeset format and version-bump rules
+
+Feed it the visual spec collected in Phase 2 of the main skill (sizes, variants, colors, states) and let it produce the token JSON and its own changeset entry. After it runs, `pnpm build:tokens` regenerates `packages/styled-system/src/tokens/generated/` so the new `--hop-comp-x-*` variables are available to consume in `X.module.css`.

--- a/.claude/skills/_port-component/references/docs-stories-tests.md
+++ b/.claude/skills/_port-component/references/docs-stories-tests.md
@@ -23,8 +23,8 @@ Optional fields: `alpha: "<caveat text>"` — shows a warning banner, use it for
 1. One or two sentences of intro prose.
 2. `<Example src="<kebab-name>/docs/preview" />` — the hero preview.
 3. `## Anatomy`
-   - `### Structure` — a fenced ` ```tsx ` block showing the JSX shape with inline comments marking optional pieces.
-   - `### Composed Components` — `<ComposedComponents components={["Avatar", "Badge", ...]}/>` listing every other Hopper component this one renders internally.
+   - `### Structure` — a fenced ` ```tsx ` block showing the JSX **a consumer actually writes** — i.e. what goes in `children` — with inline comments marking optional pieces. Don't show sub-components the component renders internally and unconditionally around/instead of `children` (e.g. a built-in close button, an internally-rendered `ButtonGroup` wrapper); those are implementation detail, not part of the public composition, and showing them makes the anatomy look like the wrong usage pattern.
+   - `### Composed Components` — `<ComposedComponents components={["Avatar", "Badge", ...]}/>` listing the Hopper components a consumer is expected to place *inside* `children` (mirrors `### Structure`) — not every component used internally by the implementation.
 4. `## Usage` — one `###` subsection per capability/prop, each with its own `<Example src="..." />`. Mirror this order to S2's own docs page structure where it makes sense, but every capability needs its own runnable example, not prose alone.
 5. `## Best Practices` — a short bullet list of do's, written as plain guidance sentences (not code).
 6. `## Props` — `<PropTable component="<PascalName>" />`. This is generated from the component's JSDoc'd props interface by `react-docgen-typescript`; there's nothing to hand-write here beyond making sure the props interface itself is well-documented (see `component-anatomy.md`).

--- a/.claude/skills/_port-component/references/docs-stories-tests.md
+++ b/.claude/skills/_port-component/references/docs-stories-tests.md
@@ -1,0 +1,129 @@
+# Docs, stories, tests, and changeset
+
+## Docs page
+
+Path: `apps/docs/content/components/<section>/<PascalName>.mdx`. The `section` is the directory (drives the sidebar); `category` is a frontmatter field (drives the overview-page grouping) — **they are different axes and often don't match.** `Tag.mdx` lives in `content/components/status/` but declares `category: "collections"`. Pick `section` for where it fits in the sidebar; pick `category` from the values `apps/docs/app/ui/components/overview/util.ts`'s `sortOrder` recognizes: `layout`, `buttons`, `collections`, `date and time`, `forms`, `icons`, `navigation`, `overlays`, `pickers`, `status`, `content`, `placeholders`, `html elements`, `building blocks`. `application` and `utilities` categories are hidden from the overview page entirely — don't use them for a normal component.
+
+Frontmatter schema, enforced by `apps/docs/contentlayer.config.ts`:
+
+```yaml
+---
+title: <PascalName>
+description: <one sentence — also shown as the overview-tile caption>
+category: "<one of the sortOrder values above>"
+links:
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/<kebab-name>/src/<PascalName>.tsx
+---
+```
+
+Optional fields: `alpha: "<caveat text>"` — shows a warning banner, use it for a freshly-ported component with known gaps (accessibility issues, incomplete states); `status` — rarely used; `menuTitle`, `isNewUntil`, `order` — cosmetic, skip unless asked.
+
+### Section order (from `Tag.mdx`, the canonical shape)
+
+1. One or two sentences of intro prose.
+2. `<Example src="<kebab-name>/docs/preview" />` — the hero preview.
+3. `## Anatomy`
+   - `### Structure` — a fenced ` ```tsx ` block showing the JSX shape with inline comments marking optional pieces.
+   - `### Composed Components` — `<ComposedComponents components={["Avatar", "Badge", ...]}/>` listing every other Hopper component this one renders internally.
+4. `## Usage` — one `###` subsection per capability/prop, each with its own `<Example src="..." />`. Mirror this order to S2's own docs page structure where it makes sense, but every capability needs its own runnable example, not prose alone.
+5. `## Best Practices` — a short bullet list of do's, written as plain guidance sentences (not code).
+6. `## Props` — `<PropTable component="<PascalName>" />`. This is generated from the component's JSDoc'd props interface by `react-docgen-typescript`; there's nothing to hand-write here beyond making sure the props interface itself is well-documented (see `component-anatomy.md`).
+7. `## Migration Notes` — `<MigrateGuide src="<kebab-name>/docs/migration-notes" />` — **only include this section if an Orbiter (the predecessor design system) equivalent actually existed.** For a brand-new component ported straight from S2 with no Orbiter history, omit this section entirely — about a third of current components correctly have no migration notes.
+
+### Examples
+
+Every `<Example src="X/docs/Y" />` resolves to a real file at `packages/components/src/X/docs/Y.tsx` (see `apps/docs/scripts/generatePreviewRef.ts` — it regexes every MDX file for `<Example src="...">` and generates lazy imports from it). Each example file is a small, runnable, self-contained snippet — import from `@hopper-ui/components` the same way an app consumer would, not from relative component internals.
+
+**Run `pnpm doc:generate` after adding/renaming any example or MDX file.** It regenerates `apps/docs/examples/Preview.ts` and `apps/docs/datas/components/*` (component prop metadata). Both are **gitignored** — run the command so docs render locally and in CI's own build step, but don't `git add` the output.
+
+## Storybook chromatic stories
+
+Path: `packages/components/src/<kebab-name>/tests/chromatic/<PascalName>.stories.tsx`. Discovered automatically by the glob `packages/**/*.stories.@(ts|tsx)` in `.storybook/main.ts` — no registration needed.
+
+```tsx
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { X } from "../../src/index.ts";
+
+const meta = {
+    title: "Components/X",
+    component: X
+} satisfies Meta<typeof X>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+    render: props => {
+        return (
+            <Stack>
+                <Inline>
+                    <X size="sm" {...props}>...</X>
+                    {/* every size/variant combination stacked so Chromatic snapshots the whole matrix in one story */}
+                </Inline>
+            </Stack>
+        );
+    }
+} satisfies Story;
+```
+
+One exported story per capability (mirrors the docs page's `## Usage` subsections) — `Default`, plus one per prop/state worth its own visual snapshot (disabled, invalid, loading, etc., following `tag/tests/chromatic/Tag.stories.tsx`). Import `Stack`/`Inline` from `../../../layout/index.ts` to lay out every size/variant together rather than writing one story per size.
+
+## Vitest tests
+
+Two files per component under `tests/vitest/`, both importing `render`/`screen` from `@hopper-ui/test-utils`:
+
+**`<PascalName>.test.tsx`** — the standard baseline every component needs, then component-specific behavior:
+
+```tsx
+import { render, screen } from "@hopper-ui/test-utils";
+import { createRef } from "react";
+
+import { X, XContext } from "../../src/index.ts";
+
+describe("X", () => {
+    it("should render with default class", () => { /* toHaveClass("hop-X") */ });
+    it("should support custom class", () => { /* custom className merges alongside hop-X */ });
+    it("should support custom style", () => { /* style-system prop + inline style both apply */ });
+    it("should support DOM props", () => { /* data-foo passthrough */ });
+    it("should support slots", () => { /* render inside <XContext.Provider value={{ slots: {...} }}> */ });
+    it("should support refs", () => { /* createRef, assert instanceof HTMLXElement */ });
+
+    // then: component-specific behavior (variants, states, interactions)
+});
+```
+
+**`<PascalName>.ssr.test.tsx`** — confirms the component doesn't throw when rendered on the server (a common RAC/browser-API pitfall):
+
+```tsx
+/**
+ * @vitest-environment node
+ */
+import { renderToString } from "react-dom/server";
+
+import { X } from "../../index.ts";
+
+describe("X", () => {
+    it("should render on the server", () => {
+        const renderOnServer = () => renderToString(<X>...</X>);
+        expect(renderOnServer).not.toThrow();
+    });
+});
+```
+
+## Changeset
+
+One file at `.changeset/<any-unused-kebab-slug>.md`. A new component is a `minor` bump on `@hopper-ui/components`; if `_update-tokens` also touched token files, include `@hopper-ui/tokens` (and `@hopper-ui/styled-system` if it regenerated) — those two typically stay `patch` even when the component itself is `minor`, unless `_update-tokens` says otherwise for that specific change.
+
+```markdown
+---
+"@hopper-ui/tokens": patch
+"@hopper-ui/components": minor
+---
+
+feat(<PascalName>): add <PascalName> component, ported from React Spectrum S2
+- Add `--hop-comp-<kebab-name>-*` tokens to both brands
+```
+
+Body is a conventional-commit-style first line plus bullets for anything notable (new tokens, sub-components, known gaps if `alpha` was used on the docs page).

--- a/.claude/skills/_port-component/references/file-layout.md
+++ b/.claude/skills/_port-component/references/file-layout.md
@@ -1,0 +1,37 @@
+# File layout for a new component
+
+Use `packages/components/src/segmented-control/` as the template — it's the newest component in the repo, has no legacy `utils/` folder, and no migration notes, so its file set is exactly what a brand-new component needs (nothing more, nothing inherited from Orbiter).
+
+```
+packages/components/src/<kebab-case-name>/     ← directory is kebab-case (e.g. action-bar/)
+├── index.ts                                   ← export * from "./src/index.ts";
+├── src/
+│   ├── <PascalName>.tsx                       ← PascalCase files (e.g. ActionBar.tsx)
+│   ├── <PascalName>.module.css
+│   ├── <PascalName>Context.ts                 ← createContext<ContextValue<...>>
+│   └── index.ts                               ← one `export * from "./X.tsx";` line per file
+├── docs/
+│   ├── preview.tsx                            ← the hero example shown at the top of the docs page
+│   └── <exampleName>.tsx                      ← one file per <Example> used in the MDX page
+└── tests/
+    ├── chromatic/
+    │   └── <PascalName>.stories.tsx
+    └── vitest/
+        ├── <PascalName>.test.tsx
+        └── <PascalName>.ssr.test.tsx
+```
+
+For a component with sub-components (e.g. `Tag` + `TagGroup`, `Avatar` + `AvatarGroup`), each sub-component gets its own `.tsx` + `.module.css` + `Context.ts` under the same `src/`, and `src/index.ts` re-exports all of them. Don't split sub-components into separate top-level component directories.
+
+If porting requires a small private helper (formatting, size-adapter maps), put it in `utils/<PascalName>.utils.ts` at the component root (see `tag/utils/Tag.utils.ts`) — only add this folder if actually needed.
+
+## Registries that must be updated
+
+1. **`packages/components/src/index.ts`** — add `export * from "./<kebab-case-name>/index.ts";` in alphabetical order among the existing exports.
+
+2. **`apps/docs/examples/overview/index.ts`** + a matching `<PascalName>.svg` under `apps/docs/examples/overview/` — this is the icon shown on the component-list overview page. **Optional**: it falls back to a generic placeholder (`EmptyComponent`) if missing, and several recent components (SegmentedControl, Callout, Tile) don't have one. Don't invent artwork — flag it as follow-up work for design instead of fabricating an SVG.
+
+That's it. Nothing else needs manual registration:
+- `apps/docs/configs/navigation.ts` is top-level nav only (Getting Started, Tokens, Icons, Styled System, Components) — components don't get individual entries there.
+- `apps/docs/content/components/overview/component-list.mdx` renders `<Overview />`, which pulls every MDX file automatically via contentlayer — no manual list to edit.
+- Storybook discovers stories via the glob `packages/**/*.stories.@(ts|tsx)` in `.storybook/main.ts` — no registration needed, just put the file in the right place.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,8 @@ Path patterns: packages/components/src/**/*.tsx
 
 ## Skills
 
-| Skill                 | When to use                                              |
-| --------------------- | -------------------------------------------------------- |
-| `update-tokens`       | Add, update, delete, or deprecate design tokens          |
-| `learn-from-feedback` | Capture a developer correction into a skill or CLAUDE.md |
+| Skill                 | When to use                                                                |
+| --------------------- | -------------------------------------------------------------------------- |
+| `update-tokens`       | Add, update, delete, or deprecate design tokens                            |
+| `learn-from-feedback` | Capture a developer correction into a skill or CLAUDE.md                   |
+| `port-component`      | Port a new component into Hopper from its React Spectrum S2 implementation |

--- a/apps/docs/content/components/collections/ActionBar.mdx
+++ b/apps/docs/content/components/collections/ActionBar.mdx
@@ -1,0 +1,77 @@
+---
+title: ActionBar
+description: An action bar shows contextual actions for the items a user has currently selected in a collection.
+category: "collections"
+links:
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/action-bar/src/ActionBar.tsx
+---
+
+An action bar holds the bulk actions for whatever a user has selected in a list, table, or card view. It appears as soon as something is selected, and goes away when the selection is cleared.
+
+<Example src="action-bar/docs/preview" />
+
+## Anatomy
+
+### Structure
+
+```tsx
+<ActionBar>
+    <CloseButton /> /* Clears the selection */
+    <Text /> /* The selection count */
+    <ButtonGroup /> /* One or more action buttons */
+</ActionBar>
+```
+
+### Composed Components
+
+An `ActionBar` uses the following components:
+
+<ComposedComponents components={["ButtonGroup", "CloseButton"]}/>
+
+## Usage
+
+### Actions
+
+Any Button variant can be used as an action. Follow `ButtonGroup`'s conventions: one primary action, with secondary or danger actions next to it.
+
+<Example src="action-bar/docs/actions" />
+
+### Clearing the selection
+
+The `onClearSelection` handler is called when the close button is pressed, or when the <kbd>Escape</kbd> key is pressed while the ActionBar has focus.
+
+<Example src="action-bar/docs/clearSelection" />
+
+### Selecting all items
+
+When every item is selected, pass `"all"` to `selectedItemCount` instead of a number.
+
+<Example src="action-bar/docs/allSelected" />
+
+ActionBar won't infer this from `selectedItemCount === totalItemCount`, because the two mean different things. `"all"` covers every item in the collection, including any that haven't loaded yet. A count matching the total only covers what's loaded right now. In a paginated or virtualized collection those two drift apart, so it's your call which one the user is actually looking at.
+
+### Showing a total
+
+Pass `totalItemCount` to show how many items are selected out of the total available.
+
+<Example src="action-bar/docs/totalItemCount" />
+
+### Naming the selected items
+
+The default text says "item", which works for most collections. When yours holds something more specific, pass `selectionText` to replace the whole sentence. It takes a node, or a function that receives `selectedItemCount` and `totalItemCount`.
+
+<Example src="action-bar/docs/selectionText" />
+
+It's the whole sentence and not just the noun because the surrounding words have to agree with it. French needs "3 personnes sélectionnées" but "3 fichiers sélectionnés": swapping only the noun would leave the participle wrong. Format the string in your own translation files, where the plural rules and agreement for each locale already live.
+
+## Best Practices
+
+ActionBars should:
+
+- Only appear while at least one item is selected — pass `0` to `selectedItemCount` to hide it.
+- Keep actions short and specific to the current selection (e.g. "Archive", "Delete").
+- Use `variant="danger"` sparingly, and only for destructive, irreversible actions.
+
+## Props
+
+<PropTable component="ActionBar" />

--- a/apps/docs/content/components/collections/ActionBar.mdx
+++ b/apps/docs/content/components/collections/ActionBar.mdx
@@ -16,17 +16,15 @@ An action bar holds the bulk actions for whatever a user has selected in a list,
 
 ```tsx
 <ActionBar>
-    <CloseButton /> /* Clears the selection */
-    <Text /> /* The selection count */
-    <ButtonGroup /> /* One or more action buttons */
+    <Button /> /* One or more action buttons */
 </ActionBar>
 ```
 
 ### Composed Components
 
-An `ActionBar` uses the following components:
+An `ActionBar` uses the following component:
 
-<ComposedComponents components={["ButtonGroup", "CloseButton"]}/>
+<ComposedComponents components={["Button"]}/>
 
 ## Usage
 

--- a/apps/docs/intl-loader.js
+++ b/apps/docs/intl-loader.js
@@ -1,0 +1,19 @@
+// @ts-check
+// This file can not be in TypeScript since it is a loader file used as is.
+//
+// The workspace tsconfig aliases "@hopper-ui/components" to source (packages/components/src),
+// bypassing the tsup build that normally compiles ICU plural/select strings in intl/*.json into
+// formatter functions (see tooling/tsup-intl-plugin). Without this loader, those strings are
+// imported as plain, uncompiled ICU syntax, and react-aria's LocalizedStringFormatter.format()
+// just returns them verbatim instead of interpolating. Mirrors .storybook/intl-loader.js.
+
+import { compileStrings } from "@internationalized/string-compiler";
+
+/**
+ * @param {string} code
+ */
+export default code => {
+    const json = JSON.parse(code);
+
+    return compileStrings(json);
+};

--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -1,4 +1,5 @@
 import { withContentlayer } from "next-contentlayer2";
+import path from "path";
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -21,10 +22,21 @@ const nextConfig = {
         ]
     },
     webpack(config) {
-        config.module.rules.push({
-            test: /\.svg$/i,
-            use: ["@svgr/webpack"]
-        });
+        config.module.rules.push(
+            {
+                test: /\.svg$/i,
+                use: ["@svgr/webpack"]
+            },
+            // The workspace tsconfig aliases "@hopper-ui/components" to source, bypassing the
+            // tsup build that normally compiles ICU plural/select strings in intl/*.json into
+            // formatter functions. Without this, react-aria's LocalizedStringFormatter.format()
+            // returns those strings verbatim instead of interpolating. Mirrors .storybook/intl-loader.js.
+            {
+                test: /(intl).*\.json$/,
+                loader: path.resolve("./intl-loader.js"),
+                type: "javascript/auto"
+            }
+        );
 
         return config;
     },

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -46,6 +46,8 @@
         "@hopper-ui/icons": "workspace:*",
         "@hopper-ui/svg-icons": "workspace:*",
         "@hopper-ui/tokens": "workspace:*",
+        "@internationalized/string-compiler": "3.2.6",
+        "@next/eslint-plugin-next": "16.3.0",
         "@svgr/webpack": "8.1.0",
         "@types/mdast": "4.0.4",
         "@types/node": "24.5.1",

--- a/packages/components/src/action-bar/docs/actions.tsx
+++ b/packages/components/src/action-bar/docs/actions.tsx
@@ -1,0 +1,17 @@
+import { ActionBar, Button } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <ActionBar selectedItemCount={12} onClearSelection={() => {}}>
+            <Button variant="primary" size="sm">
+                Approve
+            </Button>
+            <Button variant="secondary" size="sm">
+                Export
+            </Button>
+            <Button variant="danger" size="sm">
+                Delete
+            </Button>
+        </ActionBar>
+    );
+}

--- a/packages/components/src/action-bar/docs/allSelected.tsx
+++ b/packages/components/src/action-bar/docs/allSelected.tsx
@@ -1,0 +1,11 @@
+import { ActionBar, Button } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <ActionBar selectedItemCount="all" onClearSelection={() => {}}>
+            <Button variant="secondary" size="sm">
+                Export
+            </Button>
+        </ActionBar>
+    );
+}

--- a/packages/components/src/action-bar/docs/clearSelection.tsx
+++ b/packages/components/src/action-bar/docs/clearSelection.tsx
@@ -1,0 +1,14 @@
+import { ActionBar, Button } from "@hopper-ui/components";
+import { useState } from "react";
+
+export default function Example() {
+    const [selectedItemCount, setSelectedItemCount] = useState(5);
+
+    return (
+        <ActionBar selectedItemCount={selectedItemCount} onClearSelection={() => setSelectedItemCount(0)}>
+            <Button variant="secondary" size="sm">
+                Archive
+            </Button>
+        </ActionBar>
+    );
+}

--- a/packages/components/src/action-bar/docs/preview.tsx
+++ b/packages/components/src/action-bar/docs/preview.tsx
@@ -1,0 +1,58 @@
+import { ActionBar, Box, Button, Checkbox, Stack } from "@hopper-ui/components";
+import { useState } from "react";
+
+const items = [
+    { id: "1", label: "Design system audit" },
+    { id: "2", label: "Update onboarding flow" },
+    { id: "3", label: "Migrate legacy tokens" }
+];
+
+export default function Example() {
+    const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
+
+    const toggleKey = (id: string, isSelected: boolean) => {
+        setSelectedKeys(prev => {
+            const next = new Set(prev);
+
+            if (isSelected) {
+                next.add(id);
+            } else {
+                next.delete(id);
+            }
+
+            return next;
+        });
+    };
+
+    return (
+        <Box position="relative" width="100%" UNSAFE_minHeight="11rem">
+            <Stack gap="stack-sm">
+                {items.map(item => (
+                    <Checkbox
+                        key={item.id}
+                        isSelected={selectedKeys.has(item.id)}
+                        onChange={isSelected => toggleKey(item.id, isSelected)}
+                    >
+                        {item.label}
+                    </Checkbox>
+                ))}
+            </Stack>
+            <ActionBar
+                position="absolute"
+                left="0"
+                right="0"
+                bottom="0"
+                selectedItemCount={selectedKeys.size === items.length ? "all" : selectedKeys.size}
+                totalItemCount={items.length}
+                onClearSelection={() => setSelectedKeys(new Set())}
+            >
+                <Button variant="secondary" size="sm">
+                    Archive
+                </Button>
+                <Button variant="danger" size="sm">
+                    Delete
+                </Button>
+            </ActionBar>
+        </Box>
+    );
+}

--- a/packages/components/src/action-bar/docs/selectionText.tsx
+++ b/packages/components/src/action-bar/docs/selectionText.tsx
@@ -1,0 +1,15 @@
+import { ActionBar, Button } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <ActionBar
+            selectedItemCount={3}
+            selectionText={({ selectedItemCount }) => `${selectedItemCount} people selected`}
+            onClearSelection={() => {}}
+        >
+            <Button variant="secondary" size="sm">
+                Export
+            </Button>
+        </ActionBar>
+    );
+}

--- a/packages/components/src/action-bar/docs/totalItemCount.tsx
+++ b/packages/components/src/action-bar/docs/totalItemCount.tsx
@@ -1,0 +1,11 @@
+import { ActionBar, Button } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <ActionBar selectedItemCount={12} totalItemCount={230} onClearSelection={() => {}}>
+            <Button variant="secondary" size="sm">
+                Export
+            </Button>
+        </ActionBar>
+    );
+}

--- a/packages/components/src/action-bar/index.ts
+++ b/packages/components/src/action-bar/index.ts
@@ -1,0 +1,1 @@
+export * from "./src/index.ts";

--- a/packages/components/src/action-bar/src/ActionBar.module.css
+++ b/packages/components/src/action-bar/src/ActionBar.module.css
@@ -1,0 +1,84 @@
+.hop-ActionBar {
+    /* Default */
+    --hop-ActionBar-padding: var(--hop-space-inset-md);
+    --hop-ActionBar-background-color: var(--hop-comp-action-bar-background-color);
+    --hop-ActionBar-border-color: var(--hop-comp-action-bar-border-color);
+    --hop-ActionBar-border-radius: var(--hop-comp-action-bar-border-radius);
+    --hop-ActionBar-box-shadow: var(--hop-comp-action-bar-box-shadow);
+    --hop-ActionBar-row-gap: var(--hop-space-stack-sm);
+    --hop-ActionBar-column-gap: var(--hop-space-inline-md);
+    --hop-ActionBar-min-inline-size: 20rem;
+
+    /* Selection */
+    --hop-ActionBar-selection-gap: var(--hop-space-inline-md);
+
+    /* The width the selection block keeps before the actions wrap to their own row. */
+    --hop-ActionBar-selection-min-inline-size: 8rem;
+
+    /* Actions */
+    --hop-ActionBar-actions-gap: var(--hop-space-inline-sm);
+
+    /* Typography */
+    --hop-ActionBar-text-color: var(--hop-comp-action-bar-text-color);
+    --hop-ActionBar-text-font-family: var(--hop-body-sm-medium-font-family);
+    --hop-ActionBar-text-font-size: var(--hop-body-sm-medium-font-size);
+    --hop-ActionBar-text-font-weight: var(--hop-body-sm-medium-font-weight);
+    --hop-ActionBar-text-line-height: var(--hop-body-sm-medium-line-height);
+
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    box-sizing: border-box;
+    gap: var(--hop-ActionBar-row-gap) var(--hop-ActionBar-column-gap);
+    min-inline-size: var(--hop-ActionBar-min-inline-size);
+
+    padding: var(--hop-ActionBar-padding);
+
+    background-color: var(--hop-ActionBar-background-color);
+    border: 0.0625rem solid var(--hop-ActionBar-border-color);
+    border-radius: var(--hop-ActionBar-border-radius);
+    box-shadow: var(--hop-ActionBar-box-shadow);
+}
+
+/*
+ * Takes the leftover space so the count text truncates before anything else gives way, but keeps a
+ * floor so the actions wrap to their own row rather than squeezing the text down to an ellipsis.
+ * The min() guards containers narrower than that floor.
+ */
+.hop-ActionBar__selection {
+    display: flex;
+    flex: 1 1 auto;
+    align-items: center;
+    min-inline-size: min(var(--hop-ActionBar-selection-min-inline-size), 100%);
+    gap: var(--hop-ActionBar-selection-gap);
+}
+
+.hop-ActionBar__close-button {
+    flex: 0 0 auto;
+}
+
+.hop-ActionBar__text {
+    overflow: hidden;
+
+    min-inline-size: 0;
+
+    color: var(--hop-ActionBar-text-color);
+    font-family: var(--hop-ActionBar-text-font-family);
+    font-size: var(--hop-ActionBar-text-font-size);
+    font-weight: var(--hop-ActionBar-text-font-weight);
+    line-height: var(--hop-ActionBar-text-line-height);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/*
+ * Never shrinks, so the buttons stay legible while the text absorbs the loss. The max-inline-size
+ * caps the group at the bar's width, letting the buttons wrap among themselves once even a row of
+ * their own is too narrow.
+ */
+.hop-ActionBar .hop-ActionBar__actions {
+    flex: 0 0 auto;
+    max-inline-size: 100%;
+    gap: var(--hop-ActionBar-actions-gap);
+}

--- a/packages/components/src/action-bar/src/ActionBar.tsx
+++ b/packages/components/src/action-bar/src/ActionBar.tsx
@@ -1,0 +1,148 @@
+import { type StyledComponentProps, useStyledSystem } from "@hopper-ui/styled-system";
+import clsx from "clsx";
+import { type CSSProperties, type ForwardedRef, type ReactNode, forwardRef } from "react";
+import { FocusScope, useKeyboard } from "react-aria";
+import { useContextProps } from "react-aria-components";
+
+import { ButtonGroup, CloseButton } from "../../buttons/index.ts";
+import { useLocalizedString } from "../../i18n/index.ts";
+import { type BaseComponentDOMProps, cssModule } from "../../utils/index.ts";
+
+import { ActionBarContext } from "./ActionBarContext.ts";
+
+import styles from "./ActionBar.module.css";
+
+export const GlobalActionBarCssSelector = "hop-ActionBar";
+
+export interface ActionBarSelectionTextValues {
+    /**
+     * The number of selected items the ActionBar is linked to.
+     */
+    selectedItemCount: number | "all";
+    /**
+     * The total number of items available for selection.
+     */
+    totalItemCount?: number;
+}
+
+export interface ActionBarProps extends StyledComponentProps<BaseComponentDOMProps> {
+    /**
+     * The action buttons to display.
+     */
+    children: ReactNode;
+    /**
+     * The number of selected items the ActionBar is linked to. When 0, the ActionBar is hidden.
+     * @default 0
+     */
+    selectedItemCount?: number | "all";
+    /**
+     * The total number of items available for selection. When provided, the selection text reads
+     * "X of Y items selected" instead of just "X items selected".
+     */
+    totalItemCount?: number;
+    /**
+     * Replaces the whole selection sentence, for collections whose items aren't generically named
+     * ("3 people selected"). Accepts a node, or a function receiving the counts. The consumer owns
+     * pluralization and grammatical agreement in each locale they support.
+     */
+    selectionText?: ReactNode | ((values: ActionBarSelectionTextValues) => ReactNode);
+    /**
+     * Handler called when the ActionBar's close button is pressed, or the Escape key is pressed.
+     */
+    onClearSelection?: () => void;
+}
+
+function ActionBar(props: ActionBarProps, ref: ForwardedRef<HTMLDivElement>) {
+    [props, ref] = useContextProps(props, ref, ActionBarContext);
+    const stringFormatter = useLocalizedString();
+
+    const { stylingProps, ...ownProps } = useStyledSystem(props);
+    const {
+        children,
+        className,
+        style,
+        slot,
+        selectedItemCount = 0,
+        totalItemCount,
+        selectionText,
+        onClearSelection,
+        ...otherProps
+    } = ownProps;
+
+    const { keyboardProps } = useKeyboard({
+        onKeyDown: event => {
+            if (event.key === "Escape") {
+                onClearSelection?.();
+            } else {
+                event.continuePropagation();
+            }
+        }
+    });
+
+    if (selectedItemCount === 0) {
+        return null;
+    }
+
+    const resolvedSelectionText =
+        selectionText !== undefined
+            ? typeof selectionText === "function"
+                ? selectionText({ selectedItemCount, totalItemCount })
+                : selectionText
+            : selectedItemCount === "all"
+              ? stringFormatter.format("ActionBar.selectedAll")
+              : totalItemCount != null
+                ? stringFormatter.format("ActionBar.selectedOfTotal", {
+                      count: selectedItemCount,
+                      total: totalItemCount
+                  })
+                : stringFormatter.format("ActionBar.selected", { count: selectedItemCount });
+
+    const classNames = clsx(
+        GlobalActionBarCssSelector,
+        cssModule(styles, "hop-ActionBar"),
+        stylingProps.className,
+        className
+    );
+
+    const mergedStyles: CSSProperties = {
+        ...style,
+        ...stylingProps.style
+    };
+
+    return (
+        <FocusScope restoreFocus>
+            <div
+                {...otherProps}
+                {...keyboardProps}
+                ref={ref}
+                className={classNames}
+                style={mergedStyles}
+                slot={slot ?? undefined}
+            >
+                <div className={cssModule(styles, "hop-ActionBar__selection")}>
+                    <CloseButton
+                        className={cssModule(styles, "hop-ActionBar__close-button")}
+                        aria-label={stringFormatter.format("ActionBar.clearSelectionAriaLabel")}
+                        onPress={onClearSelection}
+                    />
+                    <span aria-live="polite" className={cssModule(styles, "hop-ActionBar__text")}>
+                        {resolvedSelectionText}
+                    </span>
+                </div>
+                <ButtonGroup size="sm" className={cssModule(styles, "hop-ActionBar__actions")}>
+                    {children}
+                </ButtonGroup>
+            </div>
+        </FocusScope>
+    );
+}
+
+/**
+ * An action bar shows contextual actions for the items a user has currently selected in a collection.
+ *
+ * [View Documentation](https://hopper.workleap.design/components/ActionBar)
+ */
+const _ActionBar = forwardRef<HTMLDivElement, ActionBarProps>(ActionBar);
+_ActionBar.displayName = "ActionBar";
+
+export { _ActionBar as ActionBar };

--- a/packages/components/src/action-bar/src/ActionBar.tsx
+++ b/packages/components/src/action-bar/src/ActionBar.tsx
@@ -121,7 +121,9 @@ function ActionBar(props: ActionBarProps, ref: ForwardedRef<HTMLDivElement>) {
 
     return (
         <FocusScope restoreFocus>
+            {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- the keydown listener only observes Escape bubbling from focusable children to clear the selection; the container itself isn't interactive. */}
             <div
+                role="group"
                 {...otherProps}
                 ref={ref}
                 className={classNames}

--- a/packages/components/src/action-bar/src/ActionBar.tsx
+++ b/packages/components/src/action-bar/src/ActionBar.tsx
@@ -1,6 +1,6 @@
 import { type StyledComponentProps, useStyledSystem } from "@hopper-ui/styled-system";
 import clsx from "clsx";
-import { type CSSProperties, type ForwardedRef, type ReactNode, forwardRef } from "react";
+import { type CSSProperties, type ForwardedRef, type KeyboardEvent, type ReactNode, forwardRef } from "react";
 import { FocusScope, useKeyboard } from "react-aria";
 import { useContextProps } from "react-aria-components";
 
@@ -50,6 +50,10 @@ export interface ActionBarProps extends StyledComponentProps<BaseComponentDOMPro
      * Handler called when the ActionBar's close button is pressed, or the Escape key is pressed.
      */
     onClearSelection?: () => void;
+    /**
+     * Handler called when a key is pressed while focus is within the ActionBar.
+     */
+    onKeyDown?: (event: KeyboardEvent<HTMLDivElement>) => void;
 }
 
 function ActionBar(props: ActionBarProps, ref: ForwardedRef<HTMLDivElement>) {
@@ -66,6 +70,7 @@ function ActionBar(props: ActionBarProps, ref: ForwardedRef<HTMLDivElement>) {
         totalItemCount,
         selectionText,
         onClearSelection,
+        onKeyDown,
         ...otherProps
     } = ownProps;
 
@@ -78,6 +83,11 @@ function ActionBar(props: ActionBarProps, ref: ForwardedRef<HTMLDivElement>) {
             }
         }
     });
+
+    const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+        onKeyDown?.(event);
+        keyboardProps.onKeyDown?.(event);
+    };
 
     if (selectedItemCount === 0) {
         return null;
@@ -105,19 +115,19 @@ function ActionBar(props: ActionBarProps, ref: ForwardedRef<HTMLDivElement>) {
     );
 
     const mergedStyles: CSSProperties = {
-        ...style,
-        ...stylingProps.style
+        ...stylingProps.style,
+        ...style
     };
 
     return (
         <FocusScope restoreFocus>
             <div
                 {...otherProps}
-                {...keyboardProps}
                 ref={ref}
                 className={classNames}
                 style={mergedStyles}
                 slot={slot ?? undefined}
+                onKeyDown={handleKeyDown}
             >
                 <div className={cssModule(styles, "hop-ActionBar__selection")}>
                     <CloseButton

--- a/packages/components/src/action-bar/src/ActionBarContext.ts
+++ b/packages/components/src/action-bar/src/ActionBarContext.ts
@@ -1,0 +1,8 @@
+import { createContext } from "react";
+import type { ContextValue } from "react-aria-components";
+
+import type { ActionBarProps } from "./ActionBar.tsx";
+
+export const ActionBarContext = createContext<ContextValue<ActionBarProps, HTMLDivElement>>({});
+
+ActionBarContext.displayName = "ActionBarContext";

--- a/packages/components/src/action-bar/src/index.ts
+++ b/packages/components/src/action-bar/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./ActionBar.tsx";
+export * from "./ActionBarContext.ts";

--- a/packages/components/src/action-bar/tests/chromatic/ActionBar.stories.tsx
+++ b/packages/components/src/action-bar/tests/chromatic/ActionBar.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { Button } from "../../../buttons/index.ts";
+import { Stack } from "../../../layout/index.ts";
+import { ActionBar } from "../../src/index.ts";
+
+const meta = {
+    title: "Components/ActionBar",
+    component: ActionBar
+} satisfies Meta<typeof ActionBar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+    render: props => (
+        <ActionBar selectedItemCount={12} totalItemCount={230} {...props}>
+            <Button variant="primary" size="sm">
+                Approve
+            </Button>
+            <Button variant="secondary" size="sm">
+                Export
+            </Button>
+            <Button variant="danger" size="sm">
+                Delete
+            </Button>
+        </ActionBar>
+    ),
+    args: {
+        children: null
+    }
+} satisfies Story;
+
+export const Actions = {
+    render: props => (
+        <Stack>
+            <ActionBar selectedItemCount={1} {...props}>
+                <Button variant="primary" size="sm">
+                    Primary action
+                </Button>
+            </ActionBar>
+            <ActionBar selectedItemCount={1} {...props}>
+                <Button variant="primary" size="sm">
+                    Primary action
+                </Button>
+                <Button variant="secondary" size="sm">
+                    More
+                </Button>
+            </ActionBar>
+            <ActionBar selectedItemCount={1} {...props}>
+                <Button variant="primary" size="sm">
+                    Primary action
+                </Button>
+                <Button variant="danger" size="sm">
+                    Destructive action
+                </Button>
+                <Button variant="secondary" size="sm">
+                    More
+                </Button>
+            </ActionBar>
+        </Stack>
+    ),
+    args: {
+        children: null
+    }
+} satisfies Story;
+
+export const SelectedItemCount = {
+    render: props => (
+        <Stack>
+            <ActionBar selectedItemCount={1} {...props}>
+                <Button variant="secondary" size="sm">
+                    Export
+                </Button>
+            </ActionBar>
+            <ActionBar selectedItemCount={12} totalItemCount={230} {...props}>
+                <Button variant="secondary" size="sm">
+                    Export
+                </Button>
+            </ActionBar>
+            <ActionBar selectedItemCount="all" {...props}>
+                <Button variant="secondary" size="sm">
+                    Export
+                </Button>
+            </ActionBar>
+        </Stack>
+    ),
+    args: {
+        children: null
+    }
+} satisfies Story;
+
+// Narrowing widths show the degradation chain: the count text truncates first, then the actions
+// wrap to their own row, then the buttons wrap among themselves.
+export const NarrowContainers = {
+    render: props => (
+        <Stack>
+            {["32rem", "24rem", "18rem", "12rem"].map(width => (
+                <ActionBar key={width} UNSAFE_width={width} selectedItemCount={12} totalItemCount={230} {...props}>
+                    <Button variant="primary" size="sm">
+                        Approve
+                    </Button>
+                    <Button variant="danger" size="sm">
+                        Delete
+                    </Button>
+                </ActionBar>
+            ))}
+        </Stack>
+    ),
+    args: {
+        children: null
+    }
+} satisfies Story;

--- a/packages/components/src/action-bar/tests/vitest/ActionBar.ssr.test.tsx
+++ b/packages/components/src/action-bar/tests/vitest/ActionBar.ssr.test.tsx
@@ -1,0 +1,14 @@
+/**
+ * @vitest-environment node
+ */
+import { renderToString } from "react-dom/server";
+
+import { ActionBar } from "../../src/ActionBar.tsx";
+
+describe("ActionBar", () => {
+    it("should render on the server", () => {
+        const renderOnServer = () => renderToString(<ActionBar selectedItemCount={1}>test</ActionBar>);
+
+        expect(renderOnServer).not.toThrow();
+    });
+});

--- a/packages/components/src/action-bar/tests/vitest/ActionBar.test.tsx
+++ b/packages/components/src/action-bar/tests/vitest/ActionBar.test.tsx
@@ -1,0 +1,233 @@
+import { render, screen } from "@hopper-ui/test-utils";
+import { userEvent } from "@testing-library/user-event";
+import { act, createRef } from "react";
+
+import { Button } from "../../../buttons/index.ts";
+import { ActionBar, ActionBarContext } from "../../src/index.ts";
+
+describe("ActionBar", () => {
+    it("should render with default class", () => {
+        render(
+            <ActionBar data-testid="ActionBar" selectedItemCount={1}>
+                <Button size="sm">Delete</Button>
+            </ActionBar>
+        );
+
+        const element = screen.getByTestId("ActionBar");
+        expect(element).toHaveClass("hop-ActionBar");
+    });
+
+    it("should support custom class", () => {
+        render(
+            <ActionBar data-testid="ActionBar" selectedItemCount={1} className="test">
+                <Button size="sm">Delete</Button>
+            </ActionBar>
+        );
+
+        const element = screen.getByTestId("ActionBar");
+        expect(element).toHaveClass("hop-ActionBar");
+        expect(element).toHaveClass("test");
+    });
+
+    it("should support custom style", () => {
+        render(
+            <ActionBar
+                data-testid="ActionBar"
+                selectedItemCount={1}
+                marginTop="stack-sm"
+                style={{ marginBottom: "13px" }}
+            >
+                <Button size="sm">Delete</Button>
+            </ActionBar>
+        );
+
+        const element = screen.getByTestId("ActionBar");
+        expect(element).toHaveStyle({ marginTop: "var(--hop-space-stack-sm)", marginBottom: "13px" });
+    });
+
+    it("should support DOM props", () => {
+        render(
+            <ActionBar data-testid="ActionBar" selectedItemCount={1} data-foo="bar">
+                <Button size="sm">Delete</Button>
+            </ActionBar>
+        );
+
+        const element = screen.getByTestId("ActionBar");
+        expect(element).toHaveAttribute("data-foo", "bar");
+    });
+
+    it("should support slots", () => {
+        render(
+            <ActionBarContext.Provider value={{ slots: { test: { "aria-label": "test", children: null } } }}>
+                <ActionBar data-testid="ActionBar" selectedItemCount={1} slot="test">
+                    <Button size="sm">Delete</Button>
+                </ActionBar>
+            </ActionBarContext.Provider>
+        );
+
+        const element = screen.getByTestId("ActionBar");
+        expect(element).toHaveAttribute("slot", "test");
+        expect(element).toHaveAttribute("aria-label", "test");
+    });
+
+    it("should support refs", () => {
+        const ref = createRef<HTMLDivElement>();
+        render(
+            <ActionBar selectedItemCount={1} ref={ref}>
+                <Button size="sm">Delete</Button>
+            </ActionBar>
+        );
+
+        expect(ref.current).not.toBeNull();
+        expect(ref.current instanceof HTMLDivElement).toBeTruthy();
+    });
+
+    it("should not render when selectedItemCount is 0", () => {
+        render(
+            <ActionBar data-testid="ActionBar" selectedItemCount={0}>
+                <Button size="sm">Delete</Button>
+            </ActionBar>
+        );
+
+        expect(screen.queryByTestId("ActionBar")).not.toBeInTheDocument();
+    });
+
+    it("should not render when selectedItemCount is omitted", () => {
+        render(
+            <ActionBar data-testid="ActionBar">
+                <Button size="sm">Delete</Button>
+            </ActionBar>
+        );
+
+        expect(screen.queryByTestId("ActionBar")).not.toBeInTheDocument();
+    });
+
+    it("should render the selected item count", () => {
+        render(
+            <ActionBar selectedItemCount={5}>
+                <Button size="sm">Delete</Button>
+            </ActionBar>
+        );
+
+        expect(screen.getByText("5 items selected")).toBeInTheDocument();
+    });
+
+    it("should render the selected item count against the total when totalItemCount is provided", () => {
+        render(
+            <ActionBar selectedItemCount={12} totalItemCount={230}>
+                <Button size="sm">Delete</Button>
+            </ActionBar>
+        );
+
+        expect(screen.getByText("12 of 230 items selected")).toBeInTheDocument();
+    });
+
+    it("should pluralize the total, not the selected count, when totalItemCount is provided", () => {
+        render(
+            <ActionBar selectedItemCount={1} totalItemCount={1}>
+                <Button size="sm">Delete</Button>
+            </ActionBar>
+        );
+
+        expect(screen.getByText("1 of 1 item selected")).toBeInTheDocument();
+    });
+
+    it("should render a message when every item is selected", () => {
+        render(
+            <ActionBar selectedItemCount="all">
+                <Button size="sm">Delete</Button>
+            </ActionBar>
+        );
+
+        expect(screen.getByText("All items selected")).toBeInTheDocument();
+    });
+
+    it("should render selectionText instead of the default text when given a node", () => {
+        render(
+            <ActionBar selectedItemCount={3} selectionText="3 people selected">
+                <Button size="sm">Delete</Button>
+            </ActionBar>
+        );
+
+        expect(screen.getByText("3 people selected")).toBeInTheDocument();
+        expect(screen.queryByText("3 items selected")).not.toBeInTheDocument();
+    });
+
+    it("should call selectionText with the counts when given a function", () => {
+        const selectionText = vi.fn(
+            ({ selectedItemCount, totalItemCount }) => `${selectedItemCount}/${totalItemCount} people`
+        );
+        render(
+            <ActionBar selectedItemCount={3} totalItemCount={12} selectionText={selectionText}>
+                <Button size="sm">Delete</Button>
+            </ActionBar>
+        );
+
+        expect(selectionText).toHaveBeenCalledWith({ selectedItemCount: 3, totalItemCount: 12 });
+        expect(screen.getByText("3/12 people")).toBeInTheDocument();
+    });
+
+    it("should render selectionText when every item is selected", () => {
+        render(
+            <ActionBar
+                selectedItemCount="all"
+                selectionText={({ selectedItemCount }) => `${selectedItemCount} people selected`}
+            >
+                <Button size="sm">Delete</Button>
+            </ActionBar>
+        );
+
+        expect(screen.getByText("all people selected")).toBeInTheDocument();
+    });
+
+    it("should not render when selectedItemCount is 0, even with selectionText", () => {
+        render(
+            <ActionBar data-testid="ActionBar" selectedItemCount={0} selectionText="3 people selected">
+                <Button size="sm">Delete</Button>
+            </ActionBar>
+        );
+
+        expect(screen.queryByTestId("ActionBar")).not.toBeInTheDocument();
+    });
+
+    it("should call onClearSelection when the close button is pressed", async () => {
+        const user = userEvent.setup();
+        const onClearSelection = vi.fn();
+        render(
+            <ActionBar selectedItemCount={1} onClearSelection={onClearSelection}>
+                <Button size="sm">Delete</Button>
+            </ActionBar>
+        );
+
+        await user.click(screen.getByRole("button", { name: "Clear selection" }));
+
+        expect(onClearSelection).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call onClearSelection when the Escape key is pressed", async () => {
+        const user = userEvent.setup();
+        const onClearSelection = vi.fn();
+        render(
+            <ActionBar selectedItemCount={1} onClearSelection={onClearSelection}>
+                <Button size="sm">Delete</Button>
+            </ActionBar>
+        );
+
+        act(() => {
+            screen.getByRole("button", { name: "Delete" }).focus();
+        });
+        await user.keyboard("{Escape}");
+
+        expect(onClearSelection).toHaveBeenCalledTimes(1);
+    });
+
+    it("should render its children", () => {
+        render(
+            <ActionBar selectedItemCount={1}>
+                <Button size="sm">Delete</Button>
+            </ActionBar>
+        );
+
+        expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+    });
+});

--- a/packages/components/src/i18n/intl/en-US.json
+++ b/packages/components/src/i18n/intl/en-US.json
@@ -1,4 +1,8 @@
 {
+    "ActionBar.clearSelectionAriaLabel": "Clear selection",
+    "ActionBar.selected": "{count, plural, one {# item selected} other {# items selected}}",
+    "ActionBar.selectedAll": "All items selected",
+    "ActionBar.selectedOfTotal": "{count} of {total} {total, plural, one {item} other {items}} selected",
     "Button.spinnerAriaLabel": "Loading",
     "Tag.spinnerAriaLabel": "Loading",
     "ClearButton.clearAriaLabel": "Clear",

--- a/packages/components/src/i18n/intl/fr-CA.json
+++ b/packages/components/src/i18n/intl/fr-CA.json
@@ -1,4 +1,8 @@
 {
+    "ActionBar.clearSelectionAriaLabel": "Effacer la sélection",
+    "ActionBar.selected": "{count, plural, one {# élément sélectionné} other {# éléments sélectionnés}}",
+    "ActionBar.selectedAll": "Tous les éléments sont sélectionnés",
+    "ActionBar.selectedOfTotal": "{count, plural, one {# élément sélectionné sur {total}} other {# éléments sélectionnés sur {total}}}",
     "Button.spinnerAriaLabel": "Chargement en cours",
     "Tag.spinnerAriaLabel": "Chargement en cours",
     "ClearButton.clearAriaLabel": "Effacer",

--- a/packages/components/src/i18n/tests/vitest/useLocalizedString.test.tsx
+++ b/packages/components/src/i18n/tests/vitest/useLocalizedString.test.tsx
@@ -29,6 +29,19 @@ describe("useLocalizedString", () => {
         expect(result.current.format("Input.charactersLeft", { charLeft: 3 })).toBe("3 characters left.");
     });
 
+    it("should agree the participle with the count in fr-CA", () => {
+        const { result } = renderHook(() => useLocalizedString(), undefined, { locale: "fr-CA" });
+
+        expect(result.current.format("ActionBar.selected", { count: 1 })).toBe("1 élément sélectionné");
+        expect(result.current.format("ActionBar.selected", { count: 3 })).toBe("3 éléments sélectionnés");
+        expect(result.current.format("ActionBar.selectedOfTotal", { count: 1, total: 230 })).toBe(
+            "1 élément sélectionné sur 230"
+        );
+        expect(result.current.format("ActionBar.selectedOfTotal", { count: 12, total: 230 })).toBe(
+            "12 éléments sélectionnés sur 230"
+        );
+    });
+
     it("should format and translate string when variables and fr-CA are passed", () => {
         const { result } = renderHook(() => useLocalizedString(), undefined, { locale: "fr-CA" });
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./accordion/index.ts";
+export * from "./action-bar/index.ts";
 export * from "./alert/index.ts";
 export * from "./avatar/index.ts";
 export * from "./badge/index.ts";

--- a/packages/tokens/src/tokens/components/sharegate/action-bar.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/action-bar.tokens.json
@@ -1,0 +1,24 @@
+{
+    "comp-action-bar": {
+        "background-color": {
+            "$type": "color",
+            "$value": "{neutral.surface-weak}"
+        },
+        "border-color": {
+            "$type": "color",
+            "$value": "{neutral.border}"
+        },
+        "border-radius": {
+            "$type": "borderRadius",
+            "$value": "{shape.rounded-md}"
+        },
+        "box-shadow": {
+            "$type": "shadow",
+            "$value": "{elevation.lifted}"
+        },
+        "text-color": {
+            "$type": "color",
+            "$value": "{neutral.text}"
+        }
+    }
+}

--- a/packages/tokens/src/tokens/components/workleap/action-bar.tokens.json
+++ b/packages/tokens/src/tokens/components/workleap/action-bar.tokens.json
@@ -1,0 +1,24 @@
+{
+    "comp-action-bar": {
+        "background-color": {
+            "$type": "color",
+            "$value": "{neutral.surface-weak}"
+        },
+        "border-color": {
+            "$type": "color",
+            "$value": "{neutral.border}"
+        },
+        "border-radius": {
+            "$type": "borderRadius",
+            "$value": "{shape.rounded-md}"
+        },
+        "box-shadow": {
+            "$type": "shadow",
+            "$value": "{elevation.lifted}"
+        },
+        "text-color": {
+            "$type": "color",
+            "$value": "{neutral.text}"
+        }
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,12 @@ importers:
       '@hopper-ui/tokens':
         specifier: workspace:*
         version: link:../../packages/tokens
+      '@internationalized/string-compiler':
+        specifier: 3.2.6
+        version: 3.2.6
+      '@next/eslint-plugin-next':
+        specifier: 16.3.0
+        version: 16.3.0(eslint@9.38.0(jiti@2.6.1))
       '@svgr/webpack':
         specifier: 8.1.0
         version: 8.1.0(typescript@5.5.4)
@@ -2021,6 +2027,12 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
   '@eslint-community/regexpp@4.12.1':
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
@@ -2561,6 +2573,9 @@ packages:
 
   '@next/env@16.3.0':
     resolution: {integrity: sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==}
+
+  '@next/eslint-plugin-next@16.3.0':
+    resolution: {integrity: sha512-OqgJ8PN0d04KcPhDX/PTY5tJUJZxlbrt7O7FBsm4XE0XW2JDrKnDXsc9uo9WUimJGPoo2j+JRGhyXApC//mvbw==}
 
   '@next/swc-darwin-arm64@16.3.0':
     resolution: {integrity: sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw==}
@@ -6347,6 +6362,10 @@ packages:
 
   fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+
+  fast-glob@3.3.1:
+    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
+    engines: {node: '>=8.6.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -12131,6 +12150,11 @@ snapshots:
       eslint: 9.38.0(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.38.0(jiti@2.6.1))':
+    dependencies:
+      eslint: 9.38.0(jiti@2.6.1)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.12.1': {}
 
   '@eslint/config-array@0.21.1':
@@ -12818,6 +12842,13 @@ snapshots:
   '@netlify/plugin-nextjs@5.15.13': {}
 
   '@next/env@16.3.0': {}
+
+  '@next/eslint-plugin-next@16.3.0(eslint@9.38.0(jiti@2.6.1))':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.38.0(jiti@2.6.1))
+      fast-glob: 3.3.1
+    transitivePeerDependencies:
+      - eslint
 
   '@next/swc-darwin-arm64@16.3.0':
     optional: true
@@ -16949,6 +16980,14 @@ snapshots:
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
+
+  fast-glob@3.3.1:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
 
   fast-glob@3.3.3:
     dependencies:


### PR DESCRIPTION
## Summary
- Adds the `ActionBar` component (source, tokens, docs, stories, tests, i18n strings) ported from React Spectrum S2
- Adds the `port-component` skill and dev server launch config used to build it

## Test plan
- [x] `pnpm lint` (oxlint, format, stylelint, typecheck, syncpack) passes
- [x] `pnpm test` passes (667 tests)