### PR TITLE
SGPD-9072: Make packages standalone with pnpm workspace resolution

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -4,7 +4,6 @@ import type { Options as SwcOptions } from "@swc/core";
 import { createRequire } from "node:module";
 import path, { dirname, join } from "path";
 import type { Options } from "storybook/internal/types";
-import { TsconfigPathsPlugin } from "tsconfig-paths-webpack-plugin";
 
 import { swcConfig as SwcBuildConfig } from "./swc.build.ts";
 import { swcConfig as SwcDevConfig } from "./swc.dev.ts";
@@ -36,13 +35,11 @@ const storybookConfig: StorybookConfig = {
     webpackFinal(config, { configType }) {
         config.resolve = {
             ...config.resolve,
-            plugins: [
-                ...(config.resolve?.plugins ?? []),
-                new TsconfigPathsPlugin({
-                    configFile: "./tsconfig.json",
-                    extensions: config.resolve?.extensions
-                })
-            ]
+            // Prefer the `hopper-source` export condition so internal `@hopper-ui/*` packages
+            // (including the `tooling/*` packages) resolve to their TS source (no dist build
+            // needed for HMR). Namespaced so it doesn't redirect third-party deps that ship a
+            // generic `source` condition.
+            conditionNames: ["hopper-source", ...(config.resolve?.conditionNames ?? ["..."])]
         };
 
         config.plugins = [

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -35,10 +35,6 @@ const storybookConfig: StorybookConfig = {
     webpackFinal(config, { configType }) {
         config.resolve = {
             ...config.resolve,
-            // Prefer the `hopper-source` export condition so internal `@hopper-ui/*` packages
-            // (including the `tooling/*` packages) resolve to their TS source (no dist build
-            // needed for HMR). Namespaced so it doesn't redirect third-party deps that ship a
-            // generic `source` condition.
             conditionNames: ["hopper-source", ...(config.resolve?.conditionNames ?? ["..."])]
         };
 

--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -22,6 +22,12 @@ const nextConfig = {
         ]
     },
     webpack(config) {
+        // Prefer the `hopper-source` export condition so internal `@hopper-ui/*` packages resolve
+        // to their TS source (compiled by Next via transpilePackages), matching the previous
+        // tsconfig `paths`→source behavior now that those aliases are gone. Namespaced so it
+        // doesn't redirect third-party deps that ship a generic `source` condition.
+        config.resolve.conditionNames = ["hopper-source", ...(config.resolve.conditionNames ?? ["..."])];
+
         config.module.rules.push(
             {
                 test: /\.svg$/i,

--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -22,10 +22,6 @@ const nextConfig = {
         ]
     },
     webpack(config) {
-        // Prefer the `hopper-source` export condition so internal `@hopper-ui/*` packages resolve
-        // to their TS source (compiled by Next via transpilePackages), matching the previous
-        // tsconfig `paths`→source behavior now that those aliases are gone. Namespaced so it
-        // doesn't redirect third-party deps that ship a generic `source` condition.
         config.resolve.conditionNames = ["hopper-source", ...(config.resolve.conditionNames ?? ["..."])];
 
         config.module.rules.push(

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -71,7 +71,6 @@
         "remark-stringify": "11.0.0",
         "shiki": "3.13.0",
         "shx": "0.4.0",
-        "tsconfig-paths-webpack-plugin": "4.2.0",
         "typescript": "5.5.4",
         "vfile": "6.0.3",
         "vfile-matter": "5.0.1"

--- a/apps/docs/scripts/ai-utils/tsconfig.json
+++ b/apps/docs/scripts/ai-utils/tsconfig.json
@@ -3,14 +3,10 @@
     "compilerOptions": {
         "jsx": "react-jsx",
         "baseUrl": "../..",
+        "customConditions": ["hopper-source"],
         "paths": {
             "@/*": ["./*"],
-            "@/.contentlayer/generated": ["./.contentlayer/generated/index.mjs"],
-            "@hopper-ui/icons": ["../../packages/icons/src/index.ts"],
-            "@hopper-ui/styled-system": ["../../packages/styled-system/src/index.ts"],
-            "@hopper-ui/components": ["../../packages/components/src/index.ts"],
-            "@hopper-ui/storybook-addon": ["../../tooling/storybook-addon/index.ts"],
-            "@hopper-ui/test-utils": ["../../tooling/test-utils/index.ts"]
+            "@/.contentlayer/generated": ["./.contentlayer/generated/index.mjs"]
         }
     },
     "include": [

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -7,18 +7,14 @@
         "module": "preserve",
         "moduleResolution": "Bundler",
         "baseUrl": ".",
+        "customConditions": ["hopper-source"],
         "plugins": [
             {
                 "name": "next"
             }
         ],
         "paths": {
-            "@/*": ["./*"],
-            "@hopper-ui/icons": ["../../packages/icons/src/index.ts"],
-            "@hopper-ui/styled-system": ["../../packages/styled-system/src/index.ts"],
-            "@hopper-ui/components": ["../../packages/components/src/index.ts"],
-            "@hopper-ui/storybook-addon": ["../../tooling/storybook-addon/index.ts"],
-            "@hopper-ui/test-utils": ["../../tooling/test-utils/index.ts"]
+            "@/*": ["./*"]
         }
     },
     "include": [

--- a/apps/mcp-server/tsconfig.json
+++ b/apps/mcp-server/tsconfig.json
@@ -1,7 +1,10 @@
 {
     "extends": "@workleap/typescript-configs/library.json",
     "exclude": ["dist", "node_modules"],
-    "include": ["**/*", "../../types/*"],
+    // mcp-server emits with `tsc` (allowImportingTsExtensions: false), so it can't include the whole
+    // shared `types/*`: `storybook-parameters.d.ts` imports `@hopper-ui/storybook-addon` source (whose
+    // imports use `.ts`/`.tsx` extensions). Pull in only `vitest.d.ts` for the test globals instead.
+    "include": ["**/*", "../../types/vitest.d.ts"],
     "compilerOptions": {
         "incremental": true,
         "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",

--- a/apps/mcp-server/tsconfig.json
+++ b/apps/mcp-server/tsconfig.json
@@ -1,9 +1,6 @@
 {
     "extends": "@workleap/typescript-configs/library.json",
     "exclude": ["dist", "node_modules"],
-    // mcp-server emits with `tsc` (allowImportingTsExtensions: false), so it can't include the whole
-    // shared `types/*`: `storybook-parameters.d.ts` imports `@hopper-ui/storybook-addon` source (whose
-    // imports use `.ts`/`.tsx` extensions). Pull in only `vitest.d.ts` for the test globals instead.
     "include": ["**/*", "../../types/vitest.d.ts"],
     "compilerOptions": {
         "incremental": true,

--- a/apps/samples/basic/tsconfig.json
+++ b/apps/samples/basic/tsconfig.json
@@ -5,8 +5,6 @@
     "compilerOptions": {
         "incremental": true,
         "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
-        "paths": {
-            "@hopper-ui/components": ["../../../packages/components/src/index.ts"]
-        }
+        "customConditions": ["hopper-source"]
     }
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "devDependencies": {
         "@changesets/cli": "2.29.7",
         "@chromatic-com/storybook": "5.3.0",
+        "@hopper-ui/storybook-addon": "workspace:*",
+        "@hopper-ui/test-utils": "workspace:*",
         "@hopper-ui/tokens": "workspace:*",
         "@internationalized/string-compiler": "3.2.6",
         "@netlify/plugin-nextjs": "5.15.13",
@@ -92,7 +94,6 @@
         "stylelint-use-logical": "2.1.2",
         "syncpack": "13.0.4",
         "ts-node": "10.9.2",
-        "tsconfig-paths-webpack-plugin": "4.2.0",
         "tsup": "8.5.0",
         "tsx": "4.20.6",
         "turbo": "2.5.8",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "changeset": "changeset",
         "ci-version-packages": "changeset version && pnpm build:tokens",
         "ci-release": "pnpm build:pkg && changeset publish",
-        "install-react18": "pnpm -r --filter \"{packages/**}\" add -D react@18 react-dom@18 @types/react@18 @types/react-dom@18 && pnpm add -D -w react@18 react-dom@18 @types/react@18 @types/react-dom@18",
+        "install-react18": "pnpm -r --filter \"{packages/**}\" --filter \"@hopper-ui/test-utils\" --filter \"@hopper-ui/storybook-addon\" add -D react@18 react-dom@18 @types/react@18 @types/react-dom@18 && pnpm add -D -w react@18 react-dom@18 @types/react@18 @types/react-dom@18",
         "generate-icons": "pnpm --filter=\"svg-icons\" generate-icons && pnpm --filter=\"@hopper-ui/icons*\" generate-icons",
         "lint": "oxlint && pnpm format:check && turbo run stylelint typecheck syncpack --continue",
         "oxlint": "oxlint",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -22,6 +22,7 @@
     "types": "dist/index.d.ts",
     "exports": {
         ".": {
+            "hopper-source": "./src/index.ts",
             "import": "./dist/index.js",
             "types": "./dist/index.d.ts",
             "default": "./dist/index.js"
@@ -41,7 +42,7 @@
         "find-types": "node scripts/findImportedTypes.ts"
     },
     "dependencies": {
-        "@hopper-ui/icons": "*",
+        "@hopper-ui/icons": "workspace:*",
         "@internationalized/date": "^3.10.0",
         "@react-aria/interactions": "^3.25.6",
         "@react-aria/ssr": "^3.9.10",
@@ -54,6 +55,10 @@
     "devDependencies": {
         "@hopper-ui/icons": "workspace:*",
         "@hopper-ui/styled-system": "workspace:*",
+        "@hopper-ui/tsup-css-module-plugin": "workspace:*",
+        "@hopper-ui/tsup-intl-plugin": "workspace:*",
+        "@hopper-ui/vite-intl-plugin": "workspace:*",
+        "@hopper-ui/vitest-config": "workspace:*",
         "@testing-library/dom": "10.4.1",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.0",

--- a/packages/components/tsconfig.build.json
+++ b/packages/components/tsconfig.build.json
@@ -1,8 +1,4 @@
 {
-    // Used only by `tsup.build.ts`. Clears `customConditions: ["hopper-source"]` so the tsup DTS
-    // pass resolves sibling `@hopper-ui/*` packages to their built `dist` types (external, not
-    // followed) instead of their TS source. rollup-plugin-dts cannot parse the source barrels
-    // (they import `.css`/intl `.json`). Typecheck keeps `hopper-source` via `tsconfig.json`.
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "customConditions": []

--- a/packages/components/tsconfig.build.json
+++ b/packages/components/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+    // Used only by `tsup.build.ts`. Clears `customConditions: ["hopper-source"]` so the tsup DTS
+    // pass resolves sibling `@hopper-ui/*` packages to their built `dist` types (external, not
+    // followed) instead of their TS source. rollup-plugin-dts cannot parse the source barrels
+    // (they import `.css`/intl `.json`). Typecheck keeps `hopper-source` via `tsconfig.json`.
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "customConditions": []
+    }
+}

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -5,14 +5,6 @@
     "compilerOptions": {
         "incremental": true,
         "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
-        "paths": {
-            "@hopper-ui/styled-system": ["../styled-system/src/index.ts"],
-            "@hopper-ui/components": ["../components/src/index.ts"],
-            "@hopper-ui/icons": ["../icons/src/index.ts"],
-            "@hopper-ui/storybook-addon": ["../../tooling/storybook-addon/index.ts"],
-            "@hopper-ui/test-utils": ["../../tooling/test-utils/index.ts"],
-            "@hopper-ui/tsup-css-module-plugin": ["../../tooling/tsup-css-module-plugin/index.ts"],
-            "@hopper-ui/tsup-intl-plugin": ["../../tooling/tsup-intl-plugin/index.ts"]
-        }
+        "customConditions": ["hopper-source"]
     }
 }

--- a/packages/components/tsup.build.ts
+++ b/packages/components/tsup.build.ts
@@ -11,7 +11,6 @@ const isNetlify = process.env.NETLIFY === "true";
 
 export default defineBuildConfig({
     entry: isNetlify ? ["./src/index.(ts|tsx)"] : ["./src/index.(ts|tsx)", "./src/**/src/**/*.(ts|tsx)"],
-    // Resolve sibling `@hopper-ui/*` packages from their built `dist` (not `hopper-source` source) during the DTS pass.
     tsconfig: "./tsconfig.build.json",
     target: "es2019", // We set target ES2019 since ES2020 syntax is not supported by older versions of storybook (used in orbiter)
     dts: !isNetlify,

--- a/packages/components/tsup.build.ts
+++ b/packages/components/tsup.build.ts
@@ -11,6 +11,8 @@ const isNetlify = process.env.NETLIFY === "true";
 
 export default defineBuildConfig({
     entry: isNetlify ? ["./src/index.(ts|tsx)"] : ["./src/index.(ts|tsx)", "./src/**/src/**/*.(ts|tsx)"],
+    // Resolve sibling `@hopper-ui/*` packages from their built `dist` (not `hopper-source` source) during the DTS pass.
+    tsconfig: "./tsconfig.build.json",
     target: "es2019", // We set target ES2019 since ES2020 syntax is not supported by older versions of storybook (used in orbiter)
     dts: !isNetlify,
     esbuildPlugins: [

--- a/packages/components/vitest.config.ts
+++ b/packages/components/vitest.config.ts
@@ -1,5 +1,5 @@
-import { createIntlVitePlugin } from "../../tooling/vite-intl-plugin/createIntlVitePlugin.ts";
-import { defineHopperVitestConfig } from "../../tooling/vitest-config/defineHopperVitestConfig.ts";
+import { createIntlVitePlugin } from "@hopper-ui/vite-intl-plugin";
+import { defineHopperVitestConfig } from "@hopper-ui/vitest-config";
 
 export default defineHopperVitestConfig({
     react: true,

--- a/packages/icons/docs/icon/sizes.tsx
+++ b/packages/icons/docs/icon/sizes.tsx
@@ -1,4 +1,3 @@
-import { Inline } from "@hopper-ui/components";
 import { createIcon } from "@hopper-ui/icons";
 
 import { Sparkles16, Sparkles24, Sparkles32 } from "../src/index.ts";
@@ -7,10 +6,10 @@ const CustomIcon = createIcon(Sparkles16, Sparkles24, Sparkles32, "CustomIcon");
 
 export default function Example() {
     return (
-        <Inline>
+        <div style={{ display: "flex", gap: "1rem" }}>
             <CustomIcon size="sm" />
             <CustomIcon size="md" />
             <CustomIcon size="lg" />
-        </Inline>
+        </div>
     );
 }

--- a/packages/icons/docs/richIcon/sizes.tsx
+++ b/packages/icons/docs/richIcon/sizes.tsx
@@ -1,4 +1,3 @@
-import { Inline } from "@hopper-ui/components";
 import { createRichIcon } from "@hopper-ui/icons";
 
 import { SparklesRichIcon24, SparklesRichIcon32, SparklesRichIcon40 } from "../src/index.ts";
@@ -7,10 +6,10 @@ const CustomRichIcon = createRichIcon(SparklesRichIcon24, SparklesRichIcon32, Sp
 
 export default function Example() {
     return (
-        <Inline>
+        <div style={{ display: "flex", gap: "1rem" }}>
             <CustomRichIcon size="md" />
             <CustomRichIcon size="lg" />
             <CustomRichIcon size="xl" />
-        </Inline>
+        </div>
     );
 }

--- a/packages/icons/docs/richIcon/variants.tsx
+++ b/packages/icons/docs/richIcon/variants.tsx
@@ -1,4 +1,3 @@
-import { Inline, Stack } from "@hopper-ui/components";
 import { createRichIcon } from "@hopper-ui/icons";
 
 import { SparklesRichIcon24, SparklesRichIcon32, SparklesRichIcon40 } from "../src/index.ts";
@@ -7,8 +6,8 @@ const CustomRichIcon = createRichIcon(SparklesRichIcon24, SparklesRichIcon32, Sp
 
 export default function Example() {
     return (
-        <Inline alignY="flex-start">
-            <Stack>
+        <div style={{ display: "flex", alignItems: "flex-start", gap: "1rem" }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
                 <CustomRichIcon variant="option1" />
                 <CustomRichIcon variant="option2" />
                 <CustomRichIcon variant="option3" />
@@ -17,14 +16,14 @@ export default function Example() {
                 <CustomRichIcon variant="option6" />
                 <CustomRichIcon variant="option7" />
                 <CustomRichIcon variant="option8" />
-            </Stack>
-            <Stack>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
                 <CustomRichIcon variant="success" />
                 <CustomRichIcon variant="warning" />
                 <CustomRichIcon variant="danger" />
                 <CustomRichIcon variant="information" />
                 <CustomRichIcon variant="upsell" />
-            </Stack>
-        </Inline>
+            </div>
+        </div>
     );
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -22,6 +22,7 @@
     "types": "dist/index.d.ts",
     "exports": {
         ".": {
+            "hopper-source": "./src/index.ts",
             "import": "./dist/index.js",
             "types": "./dist/index.d.ts",
             "default": "./dist/index.js"
@@ -45,6 +46,8 @@
     },
     "devDependencies": {
         "@hopper-ui/styled-system": "workspace:*",
+        "@hopper-ui/tsup-css-module-plugin": "workspace:*",
+        "@hopper-ui/vitest-config": "workspace:*",
         "@svgr/core": "8.1.0",
         "@svgr/plugin-jsx": "8.1.0",
         "@svgr/plugin-svgo": "8.1.0",

--- a/packages/icons/tsconfig.build.json
+++ b/packages/icons/tsconfig.build.json
@@ -1,8 +1,4 @@
 {
-    // Used only by `tsup.build.ts`. Clears `customConditions: ["hopper-source"]` so the tsup DTS
-    // pass resolves sibling `@hopper-ui/*` packages to their built `dist` types (external, not
-    // followed) instead of their TS source. rollup-plugin-dts cannot parse the source barrels
-    // (they import `.css`/intl `.json`). Typecheck keeps `hopper-source` via `tsconfig.json`.
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "customConditions": []

--- a/packages/icons/tsconfig.build.json
+++ b/packages/icons/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+    // Used only by `tsup.build.ts`. Clears `customConditions: ["hopper-source"]` so the tsup DTS
+    // pass resolves sibling `@hopper-ui/*` packages to their built `dist` types (external, not
+    // followed) instead of their TS source. rollup-plugin-dts cannot parse the source barrels
+    // (they import `.css`/intl `.json`). Typecheck keeps `hopper-source` via `tsconfig.json`.
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "customConditions": []
+    }
+}

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -5,13 +5,6 @@
     "compilerOptions": {
         "incremental": true,
         "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
-        "paths": {
-            "@hopper-ui/styled-system": ["../styled-system/src/index.ts"],
-            "@hopper-ui/icons": ["../icons/src/index.ts"],
-            "@hopper-ui/components": ["../components/src/index.ts"],
-            "@hopper-ui/test-utils": ["../../tooling/test-utils/index.ts"],
-            "@hopper-ui/tsup-css-module-plugin": ["../../tooling/tsup-css-module-plugin/index.ts"],
-            "@hopper-ui/storybook-addon": ["../../tooling/storybook-addon/index.ts"]
-        }
+        "customConditions": ["hopper-source"]
     }
 }

--- a/packages/icons/tsup.build.ts
+++ b/packages/icons/tsup.build.ts
@@ -5,7 +5,6 @@ import packageJson from "./package.json";
 
 export default defineBuildConfig({
     entry: ["./src/**/*.(ts|tsx)"],
-    // Resolve sibling `@hopper-ui/*` packages from their built `dist` (not `hopper-source` source) during the DTS pass.
     tsconfig: "./tsconfig.build.json",
     target: "es2019", // We set target ES2019 since ES2020 syntax is not supported by older versions of storybook (used in orbiter)
     esbuildPlugins: [

--- a/packages/icons/tsup.build.ts
+++ b/packages/icons/tsup.build.ts
@@ -5,6 +5,8 @@ import packageJson from "./package.json";
 
 export default defineBuildConfig({
     entry: ["./src/**/*.(ts|tsx)"],
+    // Resolve sibling `@hopper-ui/*` packages from their built `dist` (not `hopper-source` source) during the DTS pass.
+    tsconfig: "./tsconfig.build.json",
     target: "es2019", // We set target ES2019 since ES2020 syntax is not supported by older versions of storybook (used in orbiter)
     esbuildPlugins: [
         createCssModuleEsbuildPlugin({

--- a/packages/icons/vitest.config.ts
+++ b/packages/icons/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineHopperVitestConfig } from "../../tooling/vitest-config/defineHopperVitestConfig.ts";
+import { defineHopperVitestConfig } from "@hopper-ui/vitest-config";
 
 export default defineHopperVitestConfig({
     react: true,

--- a/packages/styled-system/package.json
+++ b/packages/styled-system/package.json
@@ -22,6 +22,7 @@
     "types": "dist/index.d.ts",
     "exports": {
         ".": {
+            "hopper-source": "./src/index.ts",
             "import": "./dist/index.js",
             "types": "./dist/index.d.ts",
             "default": "./dist/index.js"
@@ -47,6 +48,8 @@
     },
     "devDependencies": {
         "@hopper-ui/tokens": "workspace:*",
+        "@hopper-ui/tsup-css-module-plugin": "workspace:*",
+        "@hopper-ui/vitest-config": "workspace:*",
         "@testing-library/dom": "10.4.1",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.0",

--- a/packages/styled-system/tsconfig.build.json
+++ b/packages/styled-system/tsconfig.build.json
@@ -1,8 +1,4 @@
 {
-    // Used only by `tsup.build.ts`. Clears `customConditions: ["hopper-source"]` so the tsup DTS
-    // pass resolves sibling `@hopper-ui/*` packages to their built `dist` types (external, not
-    // followed) instead of their TS source. rollup-plugin-dts cannot parse the source barrels
-    // (they import `.css`/intl `.json`). Typecheck keeps `hopper-source` via `tsconfig.json`.
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "customConditions": []

--- a/packages/styled-system/tsconfig.build.json
+++ b/packages/styled-system/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+    // Used only by `tsup.build.ts`. Clears `customConditions: ["hopper-source"]` so the tsup DTS
+    // pass resolves sibling `@hopper-ui/*` packages to their built `dist` types (external, not
+    // followed) instead of their TS source. rollup-plugin-dts cannot parse the source barrels
+    // (they import `.css`/intl `.json`). Typecheck keeps `hopper-source` via `tsconfig.json`.
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "customConditions": []
+    }
+}

--- a/packages/styled-system/tsconfig.json
+++ b/packages/styled-system/tsconfig.json
@@ -5,13 +5,6 @@
     "compilerOptions": {
         "incremental": true,
         "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
-        "paths": {
-            "@hopper-ui/icons": ["../icons/src/index.ts"],
-            "@hopper-ui/components": ["../components/src/index.ts"],
-            "@hopper-ui/styled-system": ["../styled-system/src/index.ts"],
-            "@hopper-ui/test-utils": ["../../tooling/test-utils/index.ts"],
-            "@hopper-ui/tsup-css-module-plugin": ["../../tooling/tsup-css-module-plugin/index.ts"],
-            "@hopper-ui/storybook-addon": ["../../tooling/storybook-addon/index.ts"]
-        }
+        "customConditions": ["hopper-source"]
     }
 }

--- a/packages/styled-system/tsup.build.ts
+++ b/packages/styled-system/tsup.build.ts
@@ -4,7 +4,6 @@ import { defineBuildConfig } from "@workleap/tsup-configs";
 import packageJson from "./package.json";
 
 export default defineBuildConfig({
-    // Resolve sibling `@hopper-ui/*` packages from their built `dist` (not `hopper-source` source) during the DTS pass.
     tsconfig: "./tsconfig.build.json",
     entry: ["./src/**/*.(ts|tsx)"],
     target: "es2019", // We set target ES2019 since ES2020 syntax is not supported by older versions of storybook (used in orbiter)

--- a/packages/styled-system/tsup.build.ts
+++ b/packages/styled-system/tsup.build.ts
@@ -4,6 +4,8 @@ import { defineBuildConfig } from "@workleap/tsup-configs";
 import packageJson from "./package.json";
 
 export default defineBuildConfig({
+    // Resolve sibling `@hopper-ui/*` packages from their built `dist` (not `hopper-source` source) during the DTS pass.
+    tsconfig: "./tsconfig.build.json",
     entry: ["./src/**/*.(ts|tsx)"],
     target: "es2019", // We set target ES2019 since ES2020 syntax is not supported by older versions of storybook (used in orbiter)
     esbuildPlugins: [

--- a/packages/styled-system/vitest.config.ts
+++ b/packages/styled-system/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineHopperVitestConfig } from "../../tooling/vitest-config/defineHopperVitestConfig.ts";
+import { defineHopperVitestConfig } from "@hopper-ui/vitest-config";
 
 export default defineHopperVitestConfig({
     react: true,

--- a/packages/svg-icons/package.json
+++ b/packages/svg-icons/package.json
@@ -39,6 +39,7 @@
         "test": "vitest run"
     },
     "devDependencies": {
+        "@hopper-ui/vitest-config": "workspace:*",
         "@types/node": "24.5.1",
         "@workleap/typescript-configs": "3.0.4",
         "copyfiles": "2.4.1",

--- a/packages/svg-icons/vitest.config.ts
+++ b/packages/svg-icons/vitest.config.ts
@@ -1,3 +1,3 @@
-import { defineHopperVitestConfig } from "../../tooling/vitest-config/defineHopperVitestConfig.ts";
+import { defineHopperVitestConfig } from "@hopper-ui/vitest-config";
 
 export default defineHopperVitestConfig();

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -34,6 +34,7 @@
         "test": "vitest run"
     },
     "devDependencies": {
+        "@hopper-ui/vitest-config": "workspace:*",
         "@types/node": "24.5.1",
         "@workleap/tsup-configs": "3.1.0",
         "@workleap/typescript-configs": "3.0.4",

--- a/packages/tokens/tsconfig.json
+++ b/packages/tokens/tsconfig.json
@@ -5,11 +5,6 @@
     "compilerOptions": {
         "incremental": true,
         "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
-        "paths": {
-            "@hopper-ui/storybook-addon": ["../../tooling/storybook-addon/index.ts"],
-            "@hopper-ui/components": ["../components/src/index.ts"],
-            "@hopper-ui/styled-system": ["../styled-system/src/index.ts"],
-            "@hopper-ui/icons": ["../icons/src/index.ts"]
-        }
+        "customConditions": ["hopper-source"]
     }
 }

--- a/packages/tokens/vitest.config.ts
+++ b/packages/tokens/vitest.config.ts
@@ -1,3 +1,3 @@
-import { defineHopperVitestConfig } from "../../tooling/vitest-config/defineHopperVitestConfig.ts";
+import { defineHopperVitestConfig } from "@hopper-ui/vitest-config";
 
 export default defineHopperVitestConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -732,6 +732,9 @@ importers:
       '@types/react':
         specifier: 19.2.18
         version: 19.2.18
+      '@workleap/typescript-configs':
+        specifier: 3.0.4
+        version: 3.0.4(typescript@5.5.4)
       axe-playwright:
         specifier: 2.2.2
         version: 2.2.2(playwright@1.56.1)
@@ -757,6 +760,9 @@ importers:
       '@types/react':
         specifier: 19.2.18
         version: 19.2.18
+      '@workleap/typescript-configs':
+        specifier: 3.0.4
+        version: 3.0.4(typescript@5.5.4)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -773,6 +779,12 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1(postcss@8.5.6)
     devDependencies:
+      '@types/node':
+        specifier: 24.5.1
+        version: 24.5.1
+      '@workleap/typescript-configs':
+        specifier: 3.0.4
+        version: 3.0.4(typescript@5.5.4)
       tsup:
         specifier: 8.5.0
         version: 8.5.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.5.4)(yaml@2.8.1)
@@ -786,6 +798,12 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6
     devDependencies:
+      '@types/node':
+        specifier: 24.5.1
+        version: 24.5.1
+      '@workleap/typescript-configs':
+        specifier: 3.0.4
+        version: 3.0.4(typescript@5.5.4)
       tsup:
         specifier: 8.5.0
         version: 8.5.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.26)(tsx@4.20.6)(typescript@5.5.4)(yaml@2.8.1)
@@ -799,6 +817,12 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6
     devDependencies:
+      '@types/node':
+        specifier: 24.5.1
+        version: 24.5.1
+      '@workleap/typescript-configs':
+        specifier: 3.0.4
+        version: 3.0.4(typescript@5.5.4)
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -808,6 +832,9 @@ importers:
 
   tooling/vitest-config:
     devDependencies:
+      '@workleap/typescript-configs':
+        specifier: 3.0.4
+        version: 3.0.4(typescript@5.5.4)
       typescript:
         specifier: 5.5.4
         version: 5.5.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@chromatic-com/storybook':
         specifier: 5.3.0
         version: 5.3.0(storybook@10.5.7(@types/react@19.2.18)(prettier@3.6.2)(react@19.2.8))
+      '@hopper-ui/storybook-addon':
+        specifier: workspace:*
+        version: link:tooling/storybook-addon
+      '@hopper-ui/test-utils':
+        specifier: workspace:*
+        version: link:tooling/test-utils
       '@hopper-ui/tokens':
         specifier: workspace:*
         version: link:packages/tokens
@@ -128,9 +134,6 @@ importers:
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(@types/node@24.5.1)(typescript@5.5.4)
-      tsconfig-paths-webpack-plugin:
-        specifier: 4.2.0
-        version: 4.2.0
       tsup:
         specifier: 8.5.0
         version: 8.5.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.5.4)(yaml@2.8.1)
@@ -294,9 +297,6 @@ importers:
       shx:
         specifier: 0.4.0
         version: 0.4.0
-      tsconfig-paths-webpack-plugin:
-        specifier: 4.2.0
-        version: 4.2.0
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -435,8 +435,8 @@ importers:
   packages/components:
     dependencies:
       '@hopper-ui/icons':
-        specifier: '*'
-        version: 2.10.3(@hopper-ui/styled-system@packages+styled-system)(react-aria-components@1.13.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: workspace:*
+        version: link:../icons
       '@internationalized/date':
         specifier: ^3.10.0
         version: 3.10.0
@@ -465,6 +465,18 @@ importers:
       '@hopper-ui/styled-system':
         specifier: workspace:*
         version: link:../styled-system
+      '@hopper-ui/tsup-css-module-plugin':
+        specifier: workspace:*
+        version: link:../../tooling/tsup-css-module-plugin
+      '@hopper-ui/tsup-intl-plugin':
+        specifier: workspace:*
+        version: link:../../tooling/tsup-intl-plugin
+      '@hopper-ui/vite-intl-plugin':
+        specifier: workspace:*
+        version: link:../../tooling/vite-intl-plugin
+      '@hopper-ui/vitest-config':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-config
       '@testing-library/dom':
         specifier: 10.4.1
         version: 10.4.1
@@ -523,6 +535,12 @@ importers:
       '@hopper-ui/styled-system':
         specifier: workspace:*
         version: link:../styled-system
+      '@hopper-ui/tsup-css-module-plugin':
+        specifier: workspace:*
+        version: link:../../tooling/tsup-css-module-plugin
+      '@hopper-ui/vitest-config':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-config
       '@svgr/core':
         specifier: 8.1.0
         version: 8.1.0(typescript@5.5.4)
@@ -596,6 +614,12 @@ importers:
       '@hopper-ui/tokens':
         specifier: workspace:*
         version: link:../tokens
+      '@hopper-ui/tsup-css-module-plugin':
+        specifier: workspace:*
+        version: link:../../tooling/tsup-css-module-plugin
+      '@hopper-ui/vitest-config':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-config
       '@testing-library/dom':
         specifier: 10.4.1
         version: 10.4.1
@@ -641,6 +665,9 @@ importers:
 
   packages/svg-icons:
     devDependencies:
+      '@hopper-ui/vitest-config':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-config
       '@types/node':
         specifier: 24.5.1
         version: 24.5.1
@@ -668,6 +695,9 @@ importers:
 
   packages/tokens:
     devDependencies:
+      '@hopper-ui/vitest-config':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-config
       '@types/node':
         specifier: 24.5.1
         version: 24.5.1
@@ -686,6 +716,107 @@ importers:
       typescript:
         specifier: 5.5.4
         version: 5.5.4
+
+  tooling/storybook-addon:
+    dependencies:
+      '@hopper-ui/components':
+        specifier: workspace:*
+        version: link:../../packages/components
+      chromatic:
+        specifier: ^18.2.0
+        version: 18.2.0
+    devDependencies:
+      '@storybook/react-webpack5':
+        specifier: 10.5.7
+        version: 10.5.7(@swc/core@1.13.5(@swc/helpers@0.5.17))(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.25.11)(postcss@8.5.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.6.2)(react@19.2.8))(typescript@5.5.4)
+      '@types/react':
+        specifier: 19.2.18
+        version: 19.2.18
+      axe-playwright:
+        specifier: 2.2.2
+        version: 2.2.2(playwright@1.56.1)
+      react:
+        specifier: 19.2.8
+        version: 19.2.8
+      storybook:
+        specifier: 10.5.7
+        version: 10.5.7(@types/react@19.2.18)(prettier@3.6.2)(react@19.2.8)
+      typescript:
+        specifier: 5.5.4
+        version: 5.5.4
+
+  tooling/test-utils:
+    dependencies:
+      '@hopper-ui/components':
+        specifier: workspace:*
+        version: link:../../packages/components
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+    devDependencies:
+      '@types/react':
+        specifier: 19.2.18
+        version: 19.2.18
+      react:
+        specifier: 19.2.8
+        version: 19.2.8
+      typescript:
+        specifier: 5.5.4
+        version: 5.5.4
+
+  tooling/tsup-css-module-plugin:
+    dependencies:
+      postcss:
+        specifier: ^8.5.6
+        version: 8.5.6
+      postcss-modules:
+        specifier: ^6.0.1
+        version: 6.0.1(postcss@8.5.6)
+    devDependencies:
+      tsup:
+        specifier: 8.5.0
+        version: 8.5.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.5.4)(yaml@2.8.1)
+      typescript:
+        specifier: 5.5.4
+        version: 5.5.4
+
+  tooling/tsup-intl-plugin:
+    dependencies:
+      '@internationalized/string-compiler':
+        specifier: ^3.2.6
+        version: 3.2.6
+    devDependencies:
+      tsup:
+        specifier: 8.5.0
+        version: 8.5.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.26)(tsx@4.20.6)(typescript@5.5.4)(yaml@2.8.1)
+      typescript:
+        specifier: 5.5.4
+        version: 5.5.4
+
+  tooling/vite-intl-plugin:
+    dependencies:
+      '@internationalized/string-compiler':
+        specifier: ^3.2.6
+        version: 3.2.6
+    devDependencies:
+      typescript:
+        specifier: 5.5.4
+        version: 5.5.4
+      vite:
+        specifier: 8.2.1
+        version: 8.2.1(@types/node@24.5.1)(esbuild@0.25.11)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+
+  tooling/vitest-config:
+    devDependencies:
+      typescript:
+        specifier: 5.5.4
+        version: 5.5.4
+      vite:
+        specifier: 8.2.1
+        version: 8.2.1(@types/node@24.5.1)(esbuild@0.25.11)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.5.1)(happy-dom@20.11.2)(jsdom@30.0.1)(vite@8.2.1(@types/node@24.5.1)(esbuild@0.25.11)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
 
 packages:
 
@@ -2021,12 +2152,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@eslint-community/eslint-utils@4.9.0':
-    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2106,14 +2231,6 @@ packages:
 
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
-
-  '@hopper-ui/icons@2.10.3':
-    resolution: {integrity: sha512-qjlMqj2NQrNmUop5Ib4angu4E9s+zamubuzALHuzLbcBPqUWc2wYsef6jZXkE2j+tPvcY9W96yueK4jdsH8MUA==}
-    peerDependencies:
-      '@hopper-ui/styled-system': ^2.4
-      react: ^18 || ^19
-      react-aria-components: ^1.12.0
-      react-dom: ^18 || ^19
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -4134,9 +4251,6 @@ packages:
 
   '@sinonjs/fake-timers@15.4.0':
     resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
-
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -6628,10 +6742,6 @@ packages:
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
-  glob@10.4.5:
-    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
-    hasBin: true
-
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -7604,9 +7714,6 @@ packages:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
 
-  magic-string@0.30.19:
-    resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
-
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -8349,10 +8456,6 @@ packages:
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
@@ -9689,10 +9792,6 @@ packages:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -9800,10 +9899,6 @@ packages:
 
   ts-toolbelt@9.6.0:
     resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}
-
-  tsconfig-paths-webpack-plugin@4.2.0:
-    resolution: {integrity: sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==}
-    engines: {node: '>=10.13.0'}
 
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
@@ -12145,11 +12240,6 @@ snapshots:
   '@esbuild/win32-x64@0.25.11':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.38.0(jiti@2.6.1))':
-    dependencies:
-      eslint: 9.38.0(jiti@2.6.1)
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.9.1(eslint@9.38.0(jiti@2.6.1))':
     dependencies:
       eslint: 9.38.0(jiti@2.6.1)
@@ -12243,15 +12333,6 @@ snapshots:
   '@hapi/topo@5.1.0':
     dependencies:
       '@hapi/hoek': 9.3.0
-
-  '@hopper-ui/icons@2.10.3(@hopper-ui/styled-system@packages+styled-system)(react-aria-components@1.13.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@hopper-ui/styled-system': link:packages/styled-system
-      '@react-aria/utils': 3.31.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      clsx: 2.1.1
-      react: 19.2.8
-      react-aria-components: 1.13.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react-dom: 19.2.8(react@19.2.8)
 
   '@humanfs/core@0.19.1': {}
 
@@ -14504,8 +14585,6 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@standard-schema/spec@1.0.0': {}
-
   '@standard-schema/spec@1.1.0': {}
 
   '@stitches/core@1.2.8': {}
@@ -16540,7 +16619,7 @@ snapshots:
 
   effect@3.18.4:
     dependencies:
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
   electron-to-chromium@1.5.237: {}
@@ -16724,7 +16803,7 @@ snapshots:
 
   eslint@9.38.0(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.38.0(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.21.1
       '@eslint/config-helpers': 0.4.1
@@ -17023,10 +17102,6 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
-
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
@@ -17101,7 +17176,7 @@ snapshots:
 
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
-      magic-string: 0.30.19
+      magic-string: 0.30.21
       mlly: 1.8.0
       rollup: 4.52.5
 
@@ -17269,21 +17344,12 @@ snapshots:
 
   glob-to-regexp@0.4.1: {}
 
-  glob@10.4.5:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.5
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
-
   glob@10.5.0:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 9.0.5
-      minipass: 7.1.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
@@ -18552,10 +18618,6 @@ snapshots:
 
   lz-string@1.5.0: {}
 
-  magic-string@0.30.19:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -19280,7 +19342,7 @@ snapshots:
     dependencies:
       hosted-git-info: 8.1.0
       proc-log: 5.0.0
-      semver: 7.7.3
+      semver: 7.8.5
       validate-npm-package-name: 6.0.2
 
   npm-run-path@2.0.2:
@@ -19615,7 +19677,7 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   path-scurry@2.0.0:
     dependencies:
@@ -19649,8 +19711,6 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
-
-  picomatch@4.0.3: {}
 
   picomatch@4.0.5: {}
 
@@ -21258,7 +21318,7 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       commander: 4.1.1
-      glob: 10.4.5
+      glob: 10.5.0
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
@@ -21439,11 +21499,6 @@ snapshots:
 
   tinyexec@1.3.0: {}
 
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
@@ -21531,13 +21586,6 @@ snapshots:
 
   ts-toolbelt@9.6.0: {}
 
-  tsconfig-paths-webpack-plugin@4.2.0:
-    dependencies:
-      chalk: 4.1.2
-      enhanced-resolve: 5.18.3
-      tapable: 2.3.0
-      tsconfig-paths: 4.2.0
-
   tsconfig-paths@4.2.0:
     dependencies:
       json5: 2.2.3
@@ -21563,7 +21611,7 @@ snapshots:
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
       '@swc/core': 1.13.5(@swc/helpers@0.5.17)
@@ -21592,7 +21640,7 @@ snapshots:
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
       '@swc/core': 1.13.5(@swc/helpers@0.5.17)
@@ -21900,11 +21948,11 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.4
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.5
       std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.3.0
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
       vite: 8.2.1(@types/node@24.5.1)(esbuild@0.25.11)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
       why-is-node-running: 2.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -760,12 +760,18 @@ importers:
       '@types/react':
         specifier: 19.2.18
         version: 19.2.18
+      '@types/react-dom':
+        specifier: 19.2.4
+        version: 19.2.4(@types/react@19.2.18)
       '@workleap/typescript-configs':
         specifier: 3.0.4
         version: 3.0.4(typescript@5.5.4)
       react:
         specifier: 19.2.8
         version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       typescript:
         specifier: 5.5.4
         version: 5.5.4

--- a/tooling/storybook-addon/package.json
+++ b/tooling/storybook-addon/package.json
@@ -1,0 +1,28 @@
+{
+    "name": "@hopper-ui/storybook-addon",
+    "version": "0.0.0",
+    "private": true,
+    "description": "Internal Storybook addon for Hopper. Consumed as source (JIT) within the monorepo; not published.",
+    "license": "Apache-2.0",
+    "author": "Workleap",
+    "type": "module",
+    "exports": {
+        ".": "./index.ts"
+    },
+    "dependencies": {
+        "@hopper-ui/components": "workspace:*",
+        "chromatic": "^18.2.0"
+    },
+    "devDependencies": {
+        "@storybook/react-webpack5": "10.5.7",
+        "@types/react": "19.2.18",
+        "axe-playwright": "2.2.2",
+        "react": "19.2.8",
+        "storybook": "10.5.7",
+        "typescript": "5.5.4"
+    },
+    "peerDependencies": {
+        "react": "^18 || ^19",
+        "storybook": "^10.5.7"
+    }
+}

--- a/tooling/storybook-addon/package.json
+++ b/tooling/storybook-addon/package.json
@@ -9,6 +9,9 @@
     "exports": {
         ".": "./index.ts"
     },
+    "scripts": {
+        "typecheck": "tsc"
+    },
     "dependencies": {
         "@hopper-ui/components": "workspace:*",
         "chromatic": "^18.2.0"
@@ -16,6 +19,7 @@
     "devDependencies": {
         "@storybook/react-webpack5": "10.5.7",
         "@types/react": "19.2.18",
+        "@workleap/typescript-configs": "3.0.4",
         "axe-playwright": "2.2.2",
         "react": "19.2.8",
         "storybook": "10.5.7",

--- a/tooling/storybook-addon/tsconfig.json
+++ b/tooling/storybook-addon/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "extends": "@workleap/typescript-configs/library.json",
+    "exclude": ["node_modules"],
+    // `../../types/css-modules.d.ts` provides the ambient `*.css` module declaration needed because
+    // `@hopper-ui/components` resolves to source (via `hopper-source`), pulling in its `*.module.css` imports.
+    "include": ["**/*", "../../types/css-modules.d.ts"],
+    "compilerOptions": {
+        "incremental": true,
+        "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
+        "customConditions": ["hopper-source"]
+    }
+}

--- a/tooling/storybook-addon/tsconfig.json
+++ b/tooling/storybook-addon/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "extends": "@workleap/typescript-configs/library.json",
     "exclude": ["node_modules"],
-    // `../../types/css-modules.d.ts` provides the ambient `*.css` module declaration needed because
-    // `@hopper-ui/components` resolves to source (via `hopper-source`), pulling in its `*.module.css` imports.
     "include": ["**/*", "../../types/css-modules.d.ts"],
     "compilerOptions": {
         "incremental": true,

--- a/tooling/test-utils/package.json
+++ b/tooling/test-utils/package.json
@@ -18,11 +18,14 @@
     },
     "devDependencies": {
         "@types/react": "19.2.18",
+        "@types/react-dom": "19.2.4",
         "@workleap/typescript-configs": "3.0.4",
         "react": "19.2.8",
+        "react-dom": "19.2.8",
         "typescript": "5.5.4"
     },
     "peerDependencies": {
-        "react": "^18 || ^19"
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
     }
 }

--- a/tooling/test-utils/package.json
+++ b/tooling/test-utils/package.json
@@ -9,12 +9,16 @@
     "exports": {
         ".": "./index.ts"
     },
+    "scripts": {
+        "typecheck": "tsc"
+    },
     "dependencies": {
         "@hopper-ui/components": "workspace:*",
         "@testing-library/react": "^16.3.0"
     },
     "devDependencies": {
         "@types/react": "19.2.18",
+        "@workleap/typescript-configs": "3.0.4",
         "react": "19.2.8",
         "typescript": "5.5.4"
     },

--- a/tooling/test-utils/package.json
+++ b/tooling/test-utils/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "@hopper-ui/test-utils",
+    "version": "0.0.0",
+    "private": true,
+    "description": "Internal testing utilities for Hopper. Consumed as source (JIT) within the monorepo; not published.",
+    "license": "Apache-2.0",
+    "author": "Workleap",
+    "type": "module",
+    "exports": {
+        ".": "./index.ts"
+    },
+    "dependencies": {
+        "@hopper-ui/components": "workspace:*",
+        "@testing-library/react": "^16.3.0"
+    },
+    "devDependencies": {
+        "@types/react": "19.2.18",
+        "react": "19.2.8",
+        "typescript": "5.5.4"
+    },
+    "peerDependencies": {
+        "react": "^18 || ^19"
+    }
+}

--- a/tooling/test-utils/tsconfig.json
+++ b/tooling/test-utils/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "extends": "@workleap/typescript-configs/library.json",
+    "exclude": ["node_modules"],
+    // `../../types/css-modules.d.ts` provides the ambient `*.css` module declaration needed because
+    // `@hopper-ui/components` resolves to source (via `hopper-source`), pulling in its `*.module.css` imports.
+    "include": ["**/*", "../../types/css-modules.d.ts"],
+    "compilerOptions": {
+        "incremental": true,
+        "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
+        "customConditions": ["hopper-source"]
+    }
+}

--- a/tooling/test-utils/tsconfig.json
+++ b/tooling/test-utils/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "extends": "@workleap/typescript-configs/library.json",
     "exclude": ["node_modules"],
-    // `../../types/css-modules.d.ts` provides the ambient `*.css` module declaration needed because
-    // `@hopper-ui/components` resolves to source (via `hopper-source`), pulling in its `*.module.css` imports.
     "include": ["**/*", "../../types/css-modules.d.ts"],
     "compilerOptions": {
         "incremental": true,

--- a/tooling/tsup-css-module-plugin/package.json
+++ b/tooling/tsup-css-module-plugin/package.json
@@ -9,11 +9,16 @@
     "exports": {
         ".": "./index.ts"
     },
+    "scripts": {
+        "typecheck": "tsc"
+    },
     "dependencies": {
         "postcss": "^8.5.6",
         "postcss-modules": "^6.0.1"
     },
     "devDependencies": {
+        "@types/node": "24.5.1",
+        "@workleap/typescript-configs": "3.0.4",
         "tsup": "8.5.0",
         "typescript": "5.5.4"
     }

--- a/tooling/tsup-css-module-plugin/package.json
+++ b/tooling/tsup-css-module-plugin/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "@hopper-ui/tsup-css-module-plugin",
+    "version": "0.0.0",
+    "private": true,
+    "description": "Internal tsup/esbuild plugin that transforms CSS modules. Consumed as source (JIT) within the monorepo; not published.",
+    "license": "Apache-2.0",
+    "author": "Workleap",
+    "type": "module",
+    "exports": {
+        ".": "./index.ts"
+    },
+    "dependencies": {
+        "postcss": "^8.5.6",
+        "postcss-modules": "^6.0.1"
+    },
+    "devDependencies": {
+        "tsup": "8.5.0",
+        "typescript": "5.5.4"
+    }
+}

--- a/tooling/tsup-css-module-plugin/tsconfig.json
+++ b/tooling/tsup-css-module-plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "@workleap/typescript-configs/library.json",
+    "exclude": ["node_modules"],
+    "compilerOptions": {
+        "incremental": true,
+        "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
+        "customConditions": ["hopper-source"]
+    }
+}

--- a/tooling/tsup-intl-plugin/package.json
+++ b/tooling/tsup-intl-plugin/package.json
@@ -9,10 +9,15 @@
     "exports": {
         ".": "./index.ts"
     },
+    "scripts": {
+        "typecheck": "tsc"
+    },
     "dependencies": {
         "@internationalized/string-compiler": "^3.2.6"
     },
     "devDependencies": {
+        "@types/node": "24.5.1",
+        "@workleap/typescript-configs": "3.0.4",
         "tsup": "8.5.0",
         "typescript": "5.5.4"
     }

--- a/tooling/tsup-intl-plugin/package.json
+++ b/tooling/tsup-intl-plugin/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "@hopper-ui/tsup-intl-plugin",
+    "version": "0.0.0",
+    "private": true,
+    "description": "Internal tsup/esbuild plugin that compiles ICU intl messages. Consumed as source (JIT) within the monorepo; not published.",
+    "license": "Apache-2.0",
+    "author": "Workleap",
+    "type": "module",
+    "exports": {
+        ".": "./index.ts"
+    },
+    "dependencies": {
+        "@internationalized/string-compiler": "^3.2.6"
+    },
+    "devDependencies": {
+        "tsup": "8.5.0",
+        "typescript": "5.5.4"
+    }
+}

--- a/tooling/tsup-intl-plugin/tsconfig.json
+++ b/tooling/tsup-intl-plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "@workleap/typescript-configs/library.json",
+    "exclude": ["node_modules"],
+    "compilerOptions": {
+        "incremental": true,
+        "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
+        "customConditions": ["hopper-source"]
+    }
+}

--- a/tooling/vite-intl-plugin/package.json
+++ b/tooling/vite-intl-plugin/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "@hopper-ui/vite-intl-plugin",
+    "version": "0.0.0",
+    "private": true,
+    "description": "Internal Vite/Vitest plugin that compiles ICU intl messages. Consumed as source (JIT) within the monorepo; not published.",
+    "license": "Apache-2.0",
+    "author": "Workleap",
+    "type": "module",
+    "exports": {
+        ".": "./createIntlVitePlugin.ts"
+    },
+    "dependencies": {
+        "@internationalized/string-compiler": "^3.2.6"
+    },
+    "devDependencies": {
+        "typescript": "5.5.4",
+        "vite": "8.2.1"
+    },
+    "peerDependencies": {
+        "vite": "^8.2.1"
+    }
+}

--- a/tooling/vite-intl-plugin/package.json
+++ b/tooling/vite-intl-plugin/package.json
@@ -9,10 +9,15 @@
     "exports": {
         ".": "./createIntlVitePlugin.ts"
     },
+    "scripts": {
+        "typecheck": "tsc"
+    },
     "dependencies": {
         "@internationalized/string-compiler": "^3.2.6"
     },
     "devDependencies": {
+        "@types/node": "24.5.1",
+        "@workleap/typescript-configs": "3.0.4",
         "typescript": "5.5.4",
         "vite": "8.2.1"
     },

--- a/tooling/vite-intl-plugin/tsconfig.json
+++ b/tooling/vite-intl-plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "@workleap/typescript-configs/library.json",
+    "exclude": ["node_modules"],
+    "compilerOptions": {
+        "incremental": true,
+        "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
+        "customConditions": ["hopper-source"]
+    }
+}

--- a/tooling/vitest-config/defineHopperVitestConfig.ts
+++ b/tooling/vitest-config/defineHopperVitestConfig.ts
@@ -8,30 +8,10 @@ export interface HopperVitestOptions {
     plugins?: PluginOption[];
 }
 
-/**
- * Shared Vitest config factory for the Hopper packages. Replaces the per-package
- * Jest + `@swc/jest` setup: esbuild transforms TS/TSX out of the box, jsdom
- * provides the DOM, and `globals: true` keeps the existing bare
- * `describe/it/expect` calls working.
- *
- * jsdom (not happy-dom) is used deliberately, for parity with the previous Jest
- * runs: (1) `getComputedStyle` returns the literal `var(--hop-*)` value that
- * `toHaveStyle` assertions rely on (happy-dom returns empty for unresolved custom
- * properties); (2) jsdom has no `matchMedia`, so the styled-system feature-detect
- * guards keep returning false as they did under Jest.
- *
- * The `include` glob matches both test layouts: `components` keeps its tests under
- * `src/**`, while icons/styled-system/svg-icons/tokens keep them at the package
- * root under `tests/`.
- */
+/** Shared Vitest config factory for the Hopper packages. */
 export function defineHopperVitestConfig({ react = false, setupFiles = [], plugins = [] }: HopperVitestOptions = {}) {
     return defineConfig({
         plugins,
-        // `conditions: ["hopper-source"]` resolves internal `@hopper-ui/*` packages (including the
-        // `tooling/*` packages) to their TS source via the `hopper-source` export condition on the
-        // libs and the plain source `exports` on the tooling packages (no dist build needed). The
-        // name is namespaced on purpose: a generic `source` condition would also redirect
-        // third-party deps (e.g. `@internationalized/*`) to their untyped source.
         resolve: { conditions: ["hopper-source"] },
         cacheDir: "./node_modules/.cache/vitest",
         test: {

--- a/tooling/vitest-config/defineHopperVitestConfig.ts
+++ b/tooling/vitest-config/defineHopperVitestConfig.ts
@@ -27,8 +27,12 @@ export interface HopperVitestOptions {
 export function defineHopperVitestConfig({ react = false, setupFiles = [], plugins = [] }: HopperVitestOptions = {}) {
     return defineConfig({
         plugins,
-        // Vite 8 resolves tsconfig `paths` natively (replaces vite-tsconfig-paths).
-        resolve: { tsconfigPaths: true },
+        // `conditions: ["hopper-source"]` resolves internal `@hopper-ui/*` packages (including the
+        // `tooling/*` packages) to their TS source via the `hopper-source` export condition on the
+        // libs and the plain source `exports` on the tooling packages (no dist build needed). The
+        // name is namespaced on purpose: a generic `source` condition would also redirect
+        // third-party deps (e.g. `@internationalized/*`) to their untyped source.
+        resolve: { conditions: ["hopper-source"] },
         cacheDir: "./node_modules/.cache/vitest",
         test: {
             globals: true,

--- a/tooling/vitest-config/package.json
+++ b/tooling/vitest-config/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "@hopper-ui/vitest-config",
+    "version": "0.0.0",
+    "private": true,
+    "description": "Internal shared Vitest config factory for Hopper. Consumed as source (JIT) within the monorepo; not published.",
+    "license": "Apache-2.0",
+    "author": "Workleap",
+    "type": "module",
+    "exports": {
+        ".": "./defineHopperVitestConfig.ts"
+    },
+    "devDependencies": {
+        "typescript": "5.5.4",
+        "vite": "8.2.1",
+        "vitest": "4.1.10"
+    },
+    "peerDependencies": {
+        "vite": "^8.2.1",
+        "vitest": "^4.1.10"
+    }
+}

--- a/tooling/vitest-config/package.json
+++ b/tooling/vitest-config/package.json
@@ -9,7 +9,11 @@
     "exports": {
         ".": "./defineHopperVitestConfig.ts"
     },
+    "scripts": {
+        "typecheck": "tsc"
+    },
     "devDependencies": {
+        "@workleap/typescript-configs": "3.0.4",
         "typescript": "5.5.4",
         "vite": "8.2.1",
         "vitest": "4.1.10"

--- a/tooling/vitest-config/tsconfig.json
+++ b/tooling/vitest-config/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "@workleap/typescript-configs/library.json",
+    "exclude": ["node_modules"],
+    "compilerOptions": {
+        "incremental": true,
+        "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
+        "customConditions": ["hopper-source"]
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,6 @@
         "baseUrl": ".",
         "incremental": true,
         "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
-        "paths": {
-            "@hopper-ui/components": ["./packages/components/src/index.ts"],
-            "@hopper-ui/styled-system": ["./packages/styled-system/src/index.ts"],
-            "@hopper-ui/storybook-addon": ["./tooling/storybook-addon/index.ts"],
-            "@hopper-ui/icons": ["./packages/icons/src/index.ts"]
-        }
+        "customConditions": ["hopper-source"]
     }
 }


### PR DESCRIPTION
## What

Replace the duplicated `@hopper-ui/*` tsconfig `paths` aliases across every package and app with real pnpm workspace resolution backed by the namespaced `hopper-source` export condition, and convert the six `tooling/*` folders into real workspace packages (source-only Just-in-Time internal packages). Builds on the in-progress `hopper-source` migration (the three published libs already resolved source via the condition) and finishes it so there are **zero hand-authored `@hopper-ui/*` path maps left anywhere**.

## Changes

- **New packages** — `package.json` added to `storybook-addon`, `test-utils`, `tsup-css-module-plugin`, `tsup-intl-plugin`, `vite-intl-plugin`, `vitest-config`. All `private`, source-only (`exports` → `.ts`), no build step.
- **Wiring** — tooling packages declared as `workspace:*` devDependencies of their consumers (`storybook-addon`/`test-utils` are root-only to avoid a Turbo dependency cycle; they resolve everywhere via root hoisting).
- **tsconfigs** — every `@hopper-ui/*` `paths` entry deleted (root, 4 packages, both docs configs); `customConditions: ["hopper-source"]` kept.
- **Resolvers** — vitest configs now import `@hopper-ui/vitest-config` / `@hopper-ui/vite-intl-plugin` by name; dropped `tsconfigPaths` (Vitest) and `TsconfigPathsPlugin` (Storybook); removed the orphaned `tsconfig-paths-webpack-plugin` dep.
- **Build fix** — added `tsconfig.build.json` to components/styled-system/icons that clears `customConditions`, so the tsup DTS pass resolves siblings from their built `dist` types instead of source (`rollup-plugin-dts` can't parse the source barrels which import `.css`/intl `.json`).
- **Reverse ref removal** — inlined `Inline`/`Stack` to plain flex `div`s in the 3 icons docs examples, eliminating the last `icons` → `components` reverse import.

## Why

Removes the parallel `paths` maps that had to be edited in a dozen files whenever a package was added or renamed. Internal packages now resolve each other through `workspace:*` + `exports` exactly as external consumers do, simplifying the dependency graph and making each package standalone. The source-first DX (HMR/typecheck against source, no rebuild) is preserved via `hopper-source`, and published tarballs still point at `dist` so npm consumers are unaffected.

## Verification

- ✅ Grep gate: no `@hopper-ui/*` under any `paths`; no `../../tooling/` imports left
- ✅ `turbo run typecheck` (packages) + root `tsc` — clean, no `TS7053`/`@internationalized` regression
- ✅ `turbo run build --filter=./packages/*` — 5/5
- ✅ `turbo run test` — 6/6
- ✅ `syncpack lint`, `oxlint`, `oxfmt --check`
- ✅ Publish smoke test: `@hopper-ui/components` tarball ships only `dist` (0 `src/` files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)