### PR TITLE
[SGPD-9268] Remove @tanstack/react-table from the docs app

### DIFF
--- a/apps/docs/app/ui/components/propTable/PropTableRender.tsx
+++ b/apps/docs/app/ui/components/propTable/PropTableRender.tsx
@@ -1,8 +1,3 @@
-"use client";
-
-import { type ColumnDef, flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table";
-import clsx from "clsx";
-
 import type { FC, ReactNode } from "react";
 
 export interface Item {
@@ -29,84 +24,33 @@ const ColoredDefaultValue: FC<ColoredDefaultValueProps> = ({ defaultValue }) => 
     return <span style={style}>{formattedValue}</span>;
 };
 
-const columns: ColumnDef<Item>[] = [
-    {
-        id: "nameAndType",
-        accessorFn: row => ({ name: row.name, type: row.type, required: row.required }),
-        header: () => "Prop & Type",
-        cell: info => {
-            const { name, type, required } = info.getValue() as { name: ReactNode; type: ReactNode; required: boolean };
-
-            return (
-                <div className="hd-props-table__description-term">
-                    <div className="hd-props-table__name">
-                        {name}
-                        {!required && "?"}
-                    </div>
-                    <div className="hd-props-table__type">{type}</div>
-                </div>
-            );
-        }
-    },
-    {
-        id: "descriptionAndDefault",
-        accessorFn: row => ({ description: row.description, defaultValue: row.defaultValue }),
-        header: () => "Description & Default",
-        cell: info => {
-            const { description, defaultValue } = info.getValue() as { description: ReactNode; defaultValue: string };
-
-            return (
-                <div className="hd-props-table__description-list">
-                    <div className="hd-props-table__description">{description}</div>
-                    {defaultValue !== "" && (
-                        <div className="hd-props-table__default-value">
-                            <em>
-                                Defaults to <ColoredDefaultValue defaultValue={defaultValue} />.
-                            </em>
-                        </div>
-                    )}
-                </div>
-            );
-        }
-    }
-];
-
-const isColumnAvailable = (columnName: string, items: Item[]) => {
-    return items.some(item => item[columnName as keyof Item] !== "");
-};
-
 export const PropTableRender = ({ items }: { items: Item[] }) => {
-    // eslint-disable-next-line react-hooks/incompatible-library
-    const table = useReactTable({
-        columns,
-        state: {
-            columnVisibility: {
-                default: isColumnAvailable("defaultValue", items)
-            }
-        },
-        data: items,
-        getCoreRowModel: getCoreRowModel()
-    });
-
     return (
         <div className="hd-table hd-props-table">
             <div className="hd-props-table__tbody">
-                {table.getRowModel().rows.map(row => (
-                    <div key={row.id} className="hd-table__row hd-props-table__row">
-                        {row.getVisibleCells().map(cell => {
-                            return (
-                                <div
-                                    key={cell.id}
-                                    className={clsx(
-                                        "hd-table__cell",
-                                        "hd-props-table__cell",
-                                        `hd-props-table__col-${cell.column.id}`
-                                    )}
-                                >
-                                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                {items.map(({ id, name, type, defaultValue, description, required }) => (
+                    <div key={id} className="hd-table__row hd-props-table__row">
+                        <div className="hd-table__cell hd-props-table__cell hd-props-table__col-nameAndType">
+                            <div className="hd-props-table__description-term">
+                                <div className="hd-props-table__name">
+                                    {name}
+                                    {!required && "?"}
                                 </div>
-                            );
-                        })}
+                                <div className="hd-props-table__type">{type}</div>
+                            </div>
+                        </div>
+                        <div className="hd-table__cell hd-props-table__cell hd-props-table__col-descriptionAndDefault">
+                            <div className="hd-props-table__description-list">
+                                <div className="hd-props-table__description">{description}</div>
+                                {defaultValue !== "" && (
+                                    <div className="hd-props-table__default-value">
+                                        <em>
+                                            Defaults to <ColoredDefaultValue defaultValue={defaultValue} />.
+                                        </em>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
                     </div>
                 ))}
             </div>

--- a/apps/docs/app/ui/components/propTable/propTable.css
+++ b/apps/docs/app/ui/components/propTable/propTable.css
@@ -44,10 +44,6 @@
     padding: 0;
 }
 
-.hd-props-table__col-default {
-    color: var(--hd-color-neutral-text-weak);
-}
-
 .hd-props-table [data-rehype-pretty-code-figure] {
     margin: 0;
 }
@@ -73,10 +69,6 @@
     font-size: var(--hd-props-table-cell-font-size);
     font-weight: 600;
     line-height: 1.5;
-}
-
-.hd-props-table__cell.hd-props-table__col-default {
-    font-size: var(--hd-props-table-cell-font-size);
 }
 
 .hd-props-table__type [data-rehype-pretty-code-figure] [data-line] {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -22,7 +22,6 @@
         "copy:images": "node scripts/copyImages.ts"
     },
     "dependencies": {
-        "@tanstack/react-table": "8.20.5",
         "clsx": "2.1.1",
         "contentlayer2": "0.5.8",
         "next": "16.3.1",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
         "storybook": "storybook dev -p 6006",
         "storybook-nolazy": "cross-env STORYBOOK_NO_LAZY=true pnpm run storybook",
         "build-storybook": "storybook build",
-        "list-outdated-deps": "pnpm outdated -r --format list !react !react-dom !@types/react !@types/react-dom !@types/node !typescript !stylelint !@tanstack/react-table",
-        "update-outdated-deps": "pnpm update -r --latest !react !react-dom !@types/react !@types/react-dom !@types/node !typescript !stylelint !@tanstack/react-table",
+        "list-outdated-deps": "pnpm outdated -r --format list !react !react-dom !@types/react !@types/react-dom !@types/node !typescript !stylelint",
+        "update-outdated-deps": "pnpm update -r --latest !react !react-dom !@types/react !@types/react-dom !@types/node !typescript !stylelint",
         "update-react-aria-deps": "pnpm update -r react-aria react-aria-components @react-aria/* @react-stately/*",
         "find-types": "pnpm --filter=components find-types"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,9 +161,6 @@ importers:
 
   apps/docs:
     dependencies:
-      '@tanstack/react-table':
-        specifier: 8.20.5
-        version: 8.20.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -4518,17 +4515,6 @@ packages:
 
   '@swc/types@0.1.28':
     resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
-
-  '@tanstack/react-table@8.20.5':
-    resolution: {integrity: sha512-WEHopKw3znbUZ61s9i0+i9g8drmDo6asTWbrQh8Us63DAk/M0FkmIqERew6P71HI75ksZ2Pxyuf4vvKh9rAkiA==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-
-  '@tanstack/table-core@8.20.5':
-    resolution: {integrity: sha512-P9dF7XbibHph2PFRz8gfBKEXEY/HJPOhym8CHmjF8y3q5mWpKx9xtZapXQUWCgkqvsK0R46Azuz+VaxD4Xl+Tg==}
-    engines: {node: '>=12'}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -13687,14 +13673,6 @@ snapshots:
   '@swc/types@0.1.28':
     dependencies:
       '@swc/counter': 0.1.3
-
-  '@tanstack/react-table@8.20.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@tanstack/table-core': 8.20.5
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-
-  '@tanstack/table-core@8.20.5': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
## Description

Removes the `@tanstack/react-table` dependency from the docs app. Its only consumer, `PropTableRender`, used a fixed two-column layout with no sorting, filtering, or pagination, so the library added a runtime and client-bundle cost for what plain JSX renders directly.

- Rewrites `PropTableRender.tsx` as plain JSX producing the same DOM, and drops the `"use client"` directive along with it — nothing in the component needs the client once the hook is gone, and every render path into it is server-side.
- Removes dead code the library was carrying: a `columnVisibility` state keyed to a column id (`"default"`) that never matched either real column, the `isColumnAvailable` helper that computed it, and the two now-unreachable `.hd-props-table__col-default` CSS rules.
- Drops `@tanstack/react-table` from `apps/docs/package.json` and updates `pnpm-lock.yaml` accordingly.
- Removes the now-unneeded `!@tanstack/react-table` exclusion from the root `list-outdated-deps` / `update-outdated-deps` scripts (it was held at v8 while v9 shipped an API rewrite; dropping the library resolves that instead).

Jira: [SGPD-9268](https://workleap.atlassian.net/browse/SGPD-9268)

## Testing

- `pnpm i --frozen-lockfile` — manifest and lockfile agree
- `pnpm lint` (oxlint, format check, stylelint, syncpack, package typechecks) — all green
- `pnpm --filter=docs exec tsc` — no errors in the changed file (repo's existing unrelated docs-app type errors are untouched)
- `pnpm build:doc` — docs app builds and every `/components/[...slug]` prop-table page prerenders successfully
- Manually compared the rendered prop table's DOM before and after — identical, since the old `columnVisibility` state never actually hid anything


[SGPD-9268]: https://workleap.atlassian.net/browse/SGPD-9268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ