### PR TITLE
fix: use weak neutral text token for ShareGate SegmentedControl

### DIFF
--- a/.changeset/tidy-moons-listen.md
+++ b/.changeset/tidy-moons-listen.md
@@ -1,0 +1,7 @@
+---
+"@hopper-ui/tokens": patch
+"@hopper-ui/styled-system": patch
+"@hopper-ui/components": patch
+---
+
+Update the ShareGate SegmentedControl unselected text color to use the weak neutral text token instead of the weakest.

--- a/packages/tokens/src/tokens/components/sharegate/control.segmentedControl.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/control.segmentedControl.tokens.json
@@ -6,7 +6,7 @@
         },
         "text-color": {
             "$type": "color",
-            "$value": "{neutral.text-weakest}"
+            "$value": "{neutral.text-weak}"
         },
         "text-color-selected": {
             "$type": "color",


### PR DESCRIPTION
## Summary

- Changes the ShareGate `SegmentedControl` unselected item text color from `{neutral.text-weakest}` to `{neutral.text-weak}`, so unselected tabs read a little darker and clearer.
- Workleap is intentionally untouched.

The token is theme-aware, so both ShareGate themes follow automatically:

| Theme | Before | After |
| --- | --- | --- |
| Light | `rock.300` | `rock.500` |
| Dark | `rock.300` | `rock.200` |

## Notes for reviewers

- The unselected hover, focus-visible, and pressed states all re-declare `--color` to this same token (only the background changes on interaction), so those states shift along with the resting state. This is existing behaviour, not a change in this PR.
- ShareGate icons also shift with the text. `--hop-comp-segmented-control-icon-color` is defined but never referenced by the component CSS, so icons inherit the item's `color` via `fill: currentcolor`. Wiring up (or removing) those unused icon tokens is left as a follow-up.

## Test plan

- [x] `pnpm build:pkg` — generated CSS resolves `--hop-comp-segmented-control-text-color` to `var(--hop-neutral-text-weak)` for ShareGate and remains `var(--hop-neutral-text)` for Workleap
- [x] `pnpm turbo run stylelint typecheck syncpack` — 25/25 tasks pass
- [x] `pnpm test` — 665 tests across 151 files pass
- [ ] Chromatic: confirm ShareGate SegmentedControl looks right in light and dark, and that Workleap is unchanged

Made with [Cursor](https://cursor.com)