### PR TITLE
docs(agents): restructure agent instructions into routing tiers

### DIFF
--- a/.claude/rules/component-css.md
+++ b/.claude/rules/component-css.md
@@ -1,0 +1,32 @@
+---
+paths:
+  - "packages/components/src/**/*.module.css"
+---
+
+# Component CSS
+
+## Hard Rules
+
+| Rule                                                                                | Violation                                                       |
+| ----------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| Resolve every color, space, radius, typography and shadow value to a token variable | `padding: 8px`, `color: #666`                                   |
+| Read a `--hop-comp-*` token only in the component that owns it                      | `var(--hop-comp-tooltip-color)` inside `AvatarGroup.module.css` |
+| Add a missing value to the owning component's own `*.tokens.json`    | Aliasing another component's `--hop-comp-*` token               |
+| Name selectors `hop-<PascalName>`, `__descendent`, `--modifier`                      | `.btn`, `.button-label`, `.hop-button`                          |
+
+## The three token layers
+
+A module declares local variables on its root selector and aliases design tokens into them:
+
+```css
+.hop-Button {
+    --hop-Button-text-font: var(--hop-comp-button-text-font);
+    --hop-Button-column-gap: var(--hop-space-inline-xs);
+}
+```
+
+| Layer                       | Defined in                                                    | Usable from                             |
+| --------------------------- | ------------------------------------------------------------- | --------------------------------------- |
+| `--hop-comp-<component>-*`  | `packages/tokens/src/tokens/components/<brand>/*.tokens.json`  | The owning component only               |
+| `--hop-<category>-*`        | `packages/tokens/src/tokens/core/`, `.../semantic/<brand>/`    | Any component                           |
+| `--hop-<PascalName>-*`      | The component's own `.module.css`                              | That module only — an internal detail   |

--- a/.claude/rules/component-css.md
+++ b/.claude/rules/component-css.md
@@ -15,7 +15,7 @@ paths:
 | Declare a local on the module root when the component has no token file | Adding a 22nd token file for a one-off value |
 
 Stylelint already owns the mechanical layer: `px` is outside `unit-allowed-list`, and
-`selector-class-pattern` enforces `hop-<PascalName>__descendent--modifier`. Both fail at lint, so the
+`selector-class-pattern` enforces `hop-ComponentName__element-name--modifier-name`. Both fail at lint, so the
 live decisions are the ones above.
 
 ## Token families are shared, not per-component

--- a/.claude/rules/component-css.md
+++ b/.claude/rules/component-css.md
@@ -5,24 +5,41 @@ paths:
 
 # Component CSS
 
+[ADR 0004](../../docs/adr/0004-design-tokens-are-the-only-source-of-visual-values.md) and
+[ADR 0005](../../docs/adr/0005-styling-uses-style-props-and-native-css.md) own the reasoning.
+
 ## Hard Rules
 
 | Rule | Violation |
 | ---- | --------- |
+| Resolve every colour to a **semantic** token | A hex, `rgb()`, `hsl()`, or named colour |
 | Resolve a local declaration to a token, not a raw length | `--hop-MenuItem-sm-padding-block: 0.625rem` instead of a `--hop-space-*` token |
+| Prefer a semantic token over a core one — component CSS references no core colour today | Reaching past `--hop-neutral-text` to a core palette entry like `--hop-coastal-25` |
 | Read `--hop-comp-<family>-*` only from a module in that family | `list-box/src/ListBoxItem.module.css` reading `--hop-comp-select-*` |
+| Redefine a token-package property only inside `packages/tokens` | Overriding `--hop-comp-button-*` from another component's module |
 | Locate a token file by grepping its `comp-` key, not by component name | Expecting `checkbox.tokens.json`; the file is `mark.checkbox.tokens.json` |
 | Declare a local on the module root when the component has no token file | Adding a 22nd token file for a one-off value |
 
-Stylelint already owns the mechanical layer: `px` is outside `unit-allowed-list`, and
-`selector-class-pattern` enforces `hop-ComponentName__element-name--modifier-name`. Both fail at lint, so the
-live decisions are the ones above.
+Stylelint owns the mechanical layer — `px` is outside `unit-allowed-list`, `selector-class-pattern`
+enforces `hop-ComponentName__element-name--modifier-name`, and `custom-property-pattern` enforces
+`hop-ComponentName-*`. Because `px` already fails at lint, the live failure mode is a `rem` literal
+that lint permits; converting `8px` to `0.5rem` is not tokenizing it.
 
-## Token families are shared, not per-component
+## Sanctioned raw values
+
+| Case | Why |
+| ---- | --- |
+| Hairlines as `0.0625rem` — 21 in component CSS | There is no border-width token family |
+| `--hop-easing-*` referenced directly | Motion has core tokens but no semantic tier |
+| Focus rings | There is no global `--hop-focus-ring` token. Set `outline: none` in the base rule and restore it under `[data-focus-visible]`, through a local `--hop-<Component>-focus-ring-color` pointing at `--hop-primary-border-focus` or the family's `--hop-comp-*-border-color-focus` |
+| Breakpoint values | Deliberately not tokens — custom properties cannot be used in media query conditions. The scale lives in `packages/styled-system/src/responsive/Breakpoints.ts` |
+
+## Token families are shared
 
 Only 21 token files exist per brand against 90 CSS modules, and five families have no single owning
-component — `field` (read by 12 modules), `mark`, `control`, `select`, `tabs`. `comp-button` is read
-by 5 modules. Cross-family reads are the design, so the boundary is the *family*, not the file.
+component — `field` (read by 12 modules), `mark`, `control`, `select`, `tabs`. So the read boundary is
+the *family*, not the file. Reading across families is the violation. The three modules in `calendar/`
+and `date-picker/` that override `--hop-comp-button-*` are known debt, not a pattern to copy.
 
 ## The three layers
 
@@ -36,7 +53,7 @@ by 5 modules. Cross-family reads are the design, so the boundary is the *family*
 | Layer | Defined in | Read from |
 | ----- | ---------- | --------- |
 | `--hop-comp-<family>-*` | `packages/tokens/src/tokens/components/<brand>/*.tokens.json` | Modules in that family |
-| `--hop-<category>-*` | `packages/tokens/src/tokens/core/`, `.../semantic/<brand>/<light\|dark>/` | Any module |
+| `--hop-<category>-*` | `packages/tokens/src/tokens/core/`, `.../semantic/<brand>/<light\|dark>/` | Any module, semantic tier first |
 | `--hop-<PascalName>-*` | The module's own root selector | That module — unless deliberately published as a theming hook, as `--hop-RichIcon-*` is for `packages/icons` |
 
 Sibling modules inherit wholesale with `composes: hop-Input from "../../inputs/src/Input.module.css"`,

--- a/.claude/rules/component-css.md
+++ b/.claude/rules/component-css.md
@@ -7,16 +7,24 @@ paths:
 
 ## Hard Rules
 
-| Rule                                                                                | Violation                                                       |
-| ----------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| Resolve every color, space, radius, typography and shadow value to a token variable | `padding: 8px`, `color: #666`                                   |
-| Read a `--hop-comp-*` token only in the component that owns it                      | `var(--hop-comp-tooltip-color)` inside `AvatarGroup.module.css` |
-| Add a missing value to the owning component's own `*.tokens.json`    | Aliasing another component's `--hop-comp-*` token               |
-| Name selectors `hop-<PascalName>`, `__descendent`, `--modifier`                      | `.btn`, `.button-label`, `.hop-button`                          |
+| Rule | Violation |
+| ---- | --------- |
+| Resolve a local declaration to a token, not a raw length | `--hop-MenuItem-sm-padding-block: 0.625rem` instead of a `--hop-space-*` token |
+| Read `--hop-comp-<family>-*` only from a module in that family | `list-box/src/ListBoxItem.module.css` reading `--hop-comp-select-*` |
+| Locate a token file by grepping its `comp-` key, not by component name | Expecting `checkbox.tokens.json`; the file is `mark.checkbox.tokens.json` |
+| Declare a local on the module root when the component has no token file | Adding a 22nd token file for a one-off value |
 
-## The three token layers
+Stylelint already owns the mechanical layer: `px` is outside `unit-allowed-list`, and
+`selector-class-pattern` enforces `hop-<PascalName>__descendent--modifier`. Both fail at lint, so the
+live decisions are the ones above.
 
-A module declares local variables on its root selector and aliases design tokens into them:
+## Token families are shared, not per-component
+
+Only 21 token files exist per brand against 90 CSS modules, and five families have no single owning
+component — `field` (read by 12 modules), `mark`, `control`, `select`, `tabs`. `comp-button` is read
+by 5 modules. Cross-family reads are the design, so the boundary is the *family*, not the file.
+
+## The three layers
 
 ```css
 .hop-Button {
@@ -25,8 +33,12 @@ A module declares local variables on its root selector and aliases design tokens
 }
 ```
 
-| Layer                       | Defined in                                                    | Usable from                             |
-| --------------------------- | ------------------------------------------------------------- | --------------------------------------- |
-| `--hop-comp-<component>-*`  | `packages/tokens/src/tokens/components/<brand>/*.tokens.json`  | The owning component only               |
-| `--hop-<category>-*`        | `packages/tokens/src/tokens/core/`, `.../semantic/<brand>/`    | Any component                           |
-| `--hop-<PascalName>-*`      | The component's own `.module.css`                              | That module only — an internal detail   |
+| Layer | Defined in | Read from |
+| ----- | ---------- | --------- |
+| `--hop-comp-<family>-*` | `packages/tokens/src/tokens/components/<brand>/*.tokens.json` | Modules in that family |
+| `--hop-<category>-*` | `packages/tokens/src/tokens/core/`, `.../semantic/<brand>/<light\|dark>/` | Any module |
+| `--hop-<PascalName>-*` | The module's own root selector | That module — unless deliberately published as a theming hook, as `--hop-RichIcon-*` is for `packages/icons` |
+
+Sibling modules inherit wholesale with `composes: hop-Input from "../../inputs/src/Input.module.css"`,
+which pulls in the other module's class *and* its locals. Check what a `composes:` target declares
+before adding a local that may already exist there.

--- a/.claude/rules/component-tsx.md
+++ b/.claude/rules/component-tsx.md
@@ -7,15 +7,16 @@ paths:
 
 ## Hard Rules
 
-| Rule                                                                                        | Violation                                                        |
-| ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| Pass only `className` through a context object; put the visual value in the CSS module       | `[HeadingContext, { fontWeight: "heading-xs-medium" }]`          |
-| Read browser globals inside an effect or a guard, never at render or module scope            | `const w = window.innerWidth` in a component body                |
-| Derive ids from React's `useId` so the server and client markup agree                        | `id={Math.random()}`, `Date.now()` at render                     |
-| Export each component in its own statement                                                  | `export { _ComboBox as ComboBox, ListBoxItem as ComboBoxItem }`  |
+| Rule | Violation |
+| ---- | --------- |
+| Pass `className` and semantic props (`size`, `variant`, `color`, `slot`, `isHidden`) through a context object; leave raw styled-system CSS props out | `[HeadingContext, { fontWeight: "…", padding: "…" }]` |
+| Read browser globals inside an effect, a memo, or behind `useIsSSR()` | `window.matchMedia(…)` in a component body, as `SegmentedControlItem.tsx:63` still does |
+| Take `useId` from `react-aria` | `import { useId } from "react"` |
+| Export each component in its own statement | `export { _ComboBox as ComboBox, ListBoxItem as ComboBoxItem }` |
 
-Grouped exports make `react-docgen-typescript` attribute one component's props to another, which
-corrupts the generated documentation. Assign first, then export:
+Grouped exports make `react-docgen-typescript` attribute one component's props to another, corrupting
+the generated documentation — see `contributing/components.md`. All 101 exports are currently clean;
+the rule is a regression guard. Assign first, then export:
 
 ```tsx
 export const ComboBoxItem = ListBoxItem;
@@ -24,16 +25,21 @@ export { _ComboBox as ComboBox };
 
 ## Server rendering
 
-Every component carries a `tests/vitest/<Name>.ssr.test.tsx` proving it renders under Node. Add one
-with each new component:
+71 of 116 components have a `tests/vitest/<Name>.ssr.test.tsx`. Add one with every new component:
 
 ```tsx
 /**
  * @vitest-environment node
  */
+import { renderToString } from "react-dom/server";
+
+import { Button } from "../../src/Button.tsx";
+
 describe("Button", () => {
     it("should render on the server", () => {
-        expect(() => renderToString(<Button>Cutoff</Button>)).not.toThrow();
+        const renderOnServer = () => renderToString(<Button>Cutoff</Button>);
+
+        expect(renderOnServer).not.toThrow();
     });
 });
 ```

--- a/.claude/rules/component-tsx.md
+++ b/.claude/rules/component-tsx.md
@@ -10,6 +10,10 @@ paths:
 | Rule | Violation |
 | ---- | --------- |
 | Pass `className` and semantic props (`size`, `variant`, `color`, `slot`, `isHidden`) through a context object; leave raw styled-system CSS props out | `[HeadingContext, { fontWeight: "…", padding: "…" }]` |
+| Reach for the semantic element or the React Aria component | A `div` with `onClick` and `role="button"`, which is not equivalent |
+| Give an icon-only control an accessible name, and guard it at runtime as `Button`, `ToggleButton`, `Tabs` and `RichIconAvatarImage` do | An icon-only control types accept but screen readers cannot name |
+| Leave `tabIndex` at 0 or -1 | `tabIndex={1}` — the repo is currently fully compliant |
+| Express visual values through tokens, not a hand-written inline `style` object | A literal `style={{ padding: 8 }}` |
 | Read browser globals inside an effect, a memo, or behind `useIsSSR()` | `window.matchMedia(…)` in a component body, as `SegmentedControlItem.tsx:63` still does |
 | Take `useId` from `react-aria` | `import { useId } from "react"` |
 | Export each component in its own statement | `export { _ComboBox as ComboBox, ListBoxItem as ComboBoxItem }` |
@@ -22,6 +26,9 @@ the rule is a regression guard. Assign first, then export:
 export const ComboBoxItem = ListBoxItem;
 export { _ComboBox as ComboBox };
 ```
+
+Prefer a React Aria Component over its hooks; drop to the hooks only when the component API is too
+rigid, and record why, as `TooltipTrigger` does in a code comment.
 
 ## Server rendering
 

--- a/.claude/rules/component-tsx.md
+++ b/.claude/rules/component-tsx.md
@@ -1,0 +1,39 @@
+---
+paths:
+  - "packages/components/src/**/src/*.tsx"
+---
+
+# Component TSX
+
+## Hard Rules
+
+| Rule                                                                                        | Violation                                                        |
+| ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| Pass only `className` through a context object; put the visual value in the CSS module       | `[HeadingContext, { fontWeight: "heading-xs-medium" }]`          |
+| Read browser globals inside an effect or a guard, never at render or module scope            | `const w = window.innerWidth` in a component body                |
+| Derive ids from React's `useId` so the server and client markup agree                        | `id={Math.random()}`, `Date.now()` at render                     |
+| Export each component in its own statement                                                  | `export { _ComboBox as ComboBox, ListBoxItem as ComboBoxItem }`  |
+
+Grouped exports make `react-docgen-typescript` attribute one component's props to another, which
+corrupts the generated documentation. Assign first, then export:
+
+```tsx
+export const ComboBoxItem = ListBoxItem;
+export { _ComboBox as ComboBox };
+```
+
+## Server rendering
+
+Every component carries a `tests/vitest/<Name>.ssr.test.tsx` proving it renders under Node. Add one
+with each new component:
+
+```tsx
+/**
+ * @vitest-environment node
+ */
+describe("Button", () => {
+    it("should render on the server", () => {
+        expect(() => renderToString(<Button>Cutoff</Button>)).not.toThrow();
+    });
+});
+```

--- a/.claude/rules/package-json.md
+++ b/.claude/rules/package-json.md
@@ -1,0 +1,19 @@
+---
+paths:
+  - "packages/**/package.json"
+---
+
+# Package Dependencies
+
+Hopper ships inside our products' bundles, so every runtime dependency is downloaded by every end
+user — including those on low-bandwidth connections.
+
+## Hard Rules
+
+| Rule                                                                                              | Violation                                            |
+| ------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| Reach for React, react-aria, TypeScript or CSS before adding a runtime dependency                 | Adding a date library for one format call            |
+| Write a small local utility when the need is narrow                                                | Depending on a utility library for one function      |
+| List a package under `dependencies` only when consumers load it at runtime                        | A build-only plugin in `dependencies`                |
+| Declare `devDependencies` in the package that uses them — pnpm workspace does not hoist           | Adding a package's dev tooling to the root manifest  |
+| Keep a shared dependency on one version across the workspace; `pnpm syncpack` is the check        | Two packages pinned to different react-aria versions |

--- a/.claude/rules/package-json.md
+++ b/.claude/rules/package-json.md
@@ -14,10 +14,17 @@ is downloaded by every end user — including those on low-bandwidth connections
 | ---- | --------- |
 | Reach for React, react-aria, TypeScript or CSS before adding a runtime dependency | Adding `dayjs` or `date-fns` for one format call |
 | Write a small local utility when the need is narrow | Depending on a utility library for one function |
+| Keep React Aria as the only headless primitive library | Adding Radix, Headless UI or Ark |
+| Keep styling in style props and native CSS | Adding `styled-components`, `emotion`, `stitches` or Tailwind |
 | List a package under `dependencies` only when consumers load it at runtime, or when its types are part of the published API | A build-only plugin in `dependencies` |
+| Keep `react-aria` and `react-aria-components` as peer dependencies; `@react-aria/*` and `@react-stately/*` are direct runtime deps | Promoting a peer to a runtime dependency |
 | Declare a package's own build and type tooling in that package | Putting `rslib` or `@types/react` only at the root |
 | Leave the repo-wide runners at the root and invoke them from there | Adding `vitest` or `stylelint` to a package |
+| Move the React Aria versions with `pnpm update-react-aria-deps` | Bumping one `@react-aria/*` package by hand |
 | Keep a shared dependency on one version across the workspace; `pnpm syncpack` is the check | Two packages pinned to different react-aria versions |
+
+Two lockfile entries look like violations and are not: `@stitches/core` arrives transitively through
+Sandpack, and `SizingMapping` borrows Tailwind's fraction scale as a value table, not an adoption.
 
 ## What is already allowed
 
@@ -25,10 +32,10 @@ The react-aria ecosystem is the existing stack, not a new dependency — `@inter
 `@react-aria/*`, `@react-stately/*` and `@react-types/shared` are all in scope. Two more are
 grandfathered and need no justification:
 
-| Package  | Why it stays                                                              |
-| -------- | ------------------------------------------------------------------------- |
-| `clsx`   | Used at 78 sites across components, icons and styled-system                |
-| `csstype`| Types-only, but they are part of styled-system's published API surface      |
+| Package | Why it stays |
+| ------- | ------------ |
+| `clsx` | Used at 78 sites across components, icons and styled-system |
+| `csstype` | Types-only, but they are part of styled-system's published API surface |
 
 `svg-icons` and `tokens` have zero runtime dependencies. Keep it that way.
 

--- a/.claude/rules/package-json.md
+++ b/.claude/rules/package-json.md
@@ -5,15 +5,35 @@ paths:
 
 # Package Dependencies
 
-Hopper ships inside our products' bundles, so every runtime dependency is downloaded by every end
-user — including those on low-bandwidth connections.
+These five packages are published and ship inside our products' bundles, so every runtime dependency
+is downloaded by every end user — including those on low-bandwidth connections.
 
 ## Hard Rules
 
-| Rule                                                                                              | Violation                                            |
-| ------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| Reach for React, react-aria, TypeScript or CSS before adding a runtime dependency                 | Adding a date library for one format call            |
-| Write a small local utility when the need is narrow                                                | Depending on a utility library for one function      |
-| List a package under `dependencies` only when consumers load it at runtime                        | A build-only plugin in `dependencies`                |
-| Declare `devDependencies` in the package that uses them — pnpm workspace does not hoist           | Adding a package's dev tooling to the root manifest  |
-| Keep a shared dependency on one version across the workspace; `pnpm syncpack` is the check        | Two packages pinned to different react-aria versions |
+| Rule | Violation |
+| ---- | --------- |
+| Reach for React, react-aria, TypeScript or CSS before adding a runtime dependency | Adding `dayjs` or `date-fns` for one format call |
+| Write a small local utility when the need is narrow | Depending on a utility library for one function |
+| List a package under `dependencies` only when consumers load it at runtime, or when its types are part of the published API | A build-only plugin in `dependencies` |
+| Declare a package's own build and type tooling in that package | Putting `rslib` or `@types/react` only at the root |
+| Leave the repo-wide runners at the root and invoke them from there | Adding `vitest` or `stylelint` to a package |
+| Keep a shared dependency on one version across the workspace; `pnpm syncpack` is the check | Two packages pinned to different react-aria versions |
+
+## What is already allowed
+
+The react-aria ecosystem is the existing stack, not a new dependency — `@internationalized/date`,
+`@react-aria/*`, `@react-stately/*` and `@react-types/shared` are all in scope. Two more are
+grandfathered and need no justification:
+
+| Package  | Why it stays                                                              |
+| -------- | ------------------------------------------------------------------------- |
+| `clsx`   | Used at 78 sites across components, icons and styled-system                |
+| `csstype`| Types-only, but they are part of styled-system's published API surface      |
+
+`svg-icons` and `tokens` have zero runtime dependencies. Keep it that way.
+
+## What syncpack enforces
+
+Beyond a single version repo-wide, `.syncpackrc.js` also enforces range *style*: `^` for published
+prod and peer ranges, pinned everywhere else. Two groups are deliberately exempt — `@hopper-ui/*`
+prod and peer ranges, and the `react` / `react-dom` peer ranges. Leave both alone.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 | `packages/icons/**`, `packages/svg-icons/**` | `packages/icons/AGENTS.md`            |
 | `apps/docs/**`                               | `apps/docs/AGENTS.md`                 |
 
-Claude Code attaches the rules below by glob on its own. Every other agent MUST read the one whose path matches.
+Claude Code attaches the rules below itself when it reads a matching file. Every other agent — and any subagent, which does not inherit the attachment — MUST read the one whose path matches.
 
 | Path                                      | Read                             |
 | ----------------------------------------- | -------------------------------- |
@@ -25,43 +25,52 @@ Claude Code attaches the rules below by glob on its own. Every other agent MUST 
 
 ### Trigger-based routing (MUST follow)
 
-| Trigger                                                                                    | Read                                    |
-| ------------------------------------------------------------------------------------------ | --------------------------------------- |
-| A component's public API, props, slots, composition, defaults, or event callbacks          | `docs/agents/component-architecture.md` |
-| An exported name, a CSS class name, or a token custom property consumers already depend on | `docs/agents/versioning.md`             |
-| Naming a new `.ts`/`.tsx` file or a new component directory                                | `docs/agents/typescript.md`             |
+| Trigger                                                                           | Read                                    |
+| --------------------------------------------------------------------------------- | --------------------------------------- |
+| A component's public API, props, slots, composition, defaults, or event callbacks | `docs/agents/component-architecture.md` |
+| Any exported name, CSS class name, or `--hop-*` custom property                   | `docs/agents/versioning.md`             |
+| Naming a new `.ts`/`.tsx` file or a new component directory                       | `docs/agents/typescript.md`             |
 
 ## Hard Rules (Non-Negotiable)
 
-| Rule                                                                                                             | Violation                                                        |
-| ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| ALWAYS run commands from the repo root                                                                           | `cd packages/components && npx vitest`                           |
-| NEVER run `tsc`, `oxlint`, `stylelint` or `vitest` directly inside a package                                     | `cd packages/tokens && npx tsc`                                  |
-| NEVER treat root `pnpm typecheck` as a package check — the root `tsconfig.json` excludes `packages` and `apps`   | Reporting types clean after `pnpm typecheck`                     |
-| MUST run `pnpm build:pkg` after installing and after changing a package's public API                             | Debugging an import error in an unbuilt workspace                |
-| MUST scope Turbo checks with `--filter`                                                                          | `turbo run typecheck` across every package for a one-file change |
-| NEVER add a decorative comment divider                                                                           | A row of dashes or box characters used to separate sections      |
-| ALWAYS flag an invented placeholder (URL, threshold, magic number, copy) with a `// TODO` naming what to confirm | A guessed `href="https://…"` presented as final                  |
-| ALWAYS prefer editing an existing file over creating a new one                                                   | A new utility file beside an existing one that fits              |
+| Rule                                                                                                                                                                  | Violation                                                   |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| ALWAYS run commands from the repo root                                                                                                                                | `cd packages/components && npx vitest`                      |
+| ALWAYS prefix Turbo with `pnpm exec` — `turbo` is not on `PATH`                                                                                                       | `turbo run test --filter=…` → command not found             |
+| ALWAYS pass `--filter` the package `name`, not its directory                                                                                                          | `--filter=components`, which matches no package             |
+| MUST run `pnpm build:pkg` after `pnpm i` — Storybook, the docs site and `apps/samples/basic` import CSS from `dist/`                                                  | Debugging a missing-stylesheet error in a fresh clone       |
+| Rely on the `hopper-source` condition for TypeScript changes — typecheck, tests, Storybook and the docs site read package source directly                             | Rebuilding all five packages after renaming an export       |
+| NEVER run `tsc`, `oxlint`, `stylelint` or `vitest` directly inside a package; use `pnpm exec turbo run <task> --filter=<name>`                                        | `cd packages/tokens && npx tsc`                             |
+| NEVER treat root `pnpm typecheck` as a package check — the root `tsconfig.json` excludes `packages` and `apps`, so it covers only `.storybook/`, `tooling/`, `types/` | Reporting types clean after `pnpm typecheck`                |
+| ALWAYS add a changeset for a change to a published package                                                                                                            | Editing `packages/components` with no `.changeset/` entry   |
+| NEVER add a decorative comment divider                                                                                                                                | A row of dashes or box characters used to separate sections |
+| ALWAYS flag an invented placeholder (URL, threshold, magic number, copy) with a `// TODO` naming what to confirm                                                      | A guessed `href="https://…"` presented as final             |
+| ALWAYS prefer editing an existing file over creating a new one                                                                                                        | A new utility file beside an existing one that fits         |
 
 ## Build / Test / Lint
 
 - Build: `pnpm build:pkg`
 - Test: `pnpm test`
 
+Turbo filters on the `name` field, not the directory: `@hopper-ui/components`, `@hopper-ui/icons`, `@hopper-ui/styled-system`, `@hopper-ui/svg-icons`, `@hopper-ui/tokens`, `@hopper-ui/mcp-server`, `docs`, `basic`.
+
 After making changes, you MUST ALWAYS validate.
 
-| What you changed      | Run this                                                    | It must pass                                            |
-| --------------------- | ----------------------------------------------------------- | ------------------------------------------------------- |
-| A package source file | `pnpm build:pkg`                                            | Build succeeds                                          |
-| Logic or behavior     | `turbo run test --filter=<package>`                         | All unit tests pass                                     |
-| Code or types         | `turbo run typecheck --filter=<package>`                    | No type errors                                          |
-| CSS                   | `turbo run stylelint --filter=<package>`                    | No lint errors                                          |
-| `package.json`        | `pnpm syncpack`                                             | No dependency policy violations                         |
-| Formatting            | `pnpm format`                                               | Auto-fixes; `pnpm format:check` verifies                |
-| Design tokens         | `pnpm build:tokens`                                         | Generated CSS regenerates                               |
-| Docs content          | `pnpm doc:generate && pnpm build:doc && pnpm build:ai-docs` | The site and the AI surfaces both build                 |
-| Multiple categories   | `pnpm lint`                                                 | oxlint, format:check, stylelint, typecheck and syncpack |
+| What you changed         | Run this                                        | It must pass                                            |
+| ------------------------ | ----------------------------------------------- | ------------------------------------------------------- |
+| Anything, after `pnpm i` | `pnpm build:pkg`                                | Build succeeds                                          |
+| Logic or behavior        | `pnpm exec turbo run test --filter=<name>`      | All unit tests pass                                     |
+| Code or types            | `pnpm exec turbo run typecheck --filter=<name>` | No type errors                                          |
+| CSS                      | `pnpm exec turbo run stylelint --filter=<name>` | No lint errors                                          |
+| `package.json`           | `pnpm syncpack`                                 | No dependency policy violations                         |
+| Formatting               | `pnpm format`                                   | Auto-fixes; `pnpm format:check` verifies                |
+| Design tokens            | `pnpm build:tokens && pnpm build:pkg`           | Regenerates, then rebuilds the CSS apps consume         |
+| A published package      | `pnpm changeset`                                | A `.changeset/` entry exists                            |
+| Docs content             | `pnpm build:doc`                                | Chains generate → ai-docs → skills                      |
+| MCP server               | `pnpm build:mcp`                                | Build succeeds                                          |
+| Multiple categories      | `pnpm lint`                                     | oxlint, format:check, stylelint, typecheck and syncpack |
+
+Two of these pass silently where the script is absent, so a green run can mean nothing ran: `apps/docs` has no `typecheck`, and only `@hopper-ui/components`, `@hopper-ui/icons` and `@hopper-ui/styled-system` have `stylelint`. Verify `apps/docs` with `pnpm build:doc` instead. `pnpm lint` and `pnpm test` are intentionally unfiltered.
 
 ## Workflow
 
@@ -77,7 +86,7 @@ Feature first → user confirms "Looks good" → then tests and stories. Never t
 ## Git/GitHub instructions
 
 - Branch name format: `<TICKET>-<kebab-description>`, e.g. `SGPD-9268-remove-tanstack-table`. Tickets are `SGPD-` or `SGPLTD-`.
-- Pull request title format: `[<TICKET>] <Title>`. Use a conventional-commit prefix (`fix:`, `feat(docs):`) only for a change with no ticket.
+- Pull request title format: `<TICKET>: <Title>`. `[<TICKET>] <Title>` is also accepted. Use a conventional-commit prefix (`fix:`, `feat(docs):`) for a change with no ticket.
 
 ## Skills
 
@@ -85,13 +94,13 @@ These three encode the workflows of this repository. The installed third-party s
 
 | Skill                 | When to use                                                                |
 | --------------------- | -------------------------------------------------------------------------- |
-| `update-tokens`       | Add, update, delete, or deprecate design tokens                            |
-| `port-component`      | Port a new component into Hopper from its React Spectrum S2 implementation |
+| `_update-tokens`      | Add, update, delete, or deprecate design tokens                            |
+| `_port-component`     | Port a new component into Hopper from its React Spectrum S2 implementation |
 | `learn-from-feedback` | Capture a developer correction into a skill or an instruction file         |
 
 ## Detailed Documentation
 
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** — monorepo setup, installation, and the full command list. Packages must be built before anything runs.
 - **[contributing/](contributing/)** — human-facing guides for [tokens](contributing/tokens.md), [icons](contributing/icons.md) and [components](contributing/components.md).
-- **[docs/adr/](docs/adr/)** — architectural decisions. Consult existing ADRs before proposing a change that contradicts one.
+- **[docs/adr/](docs/adr/)** — architectural decisions. Consult existing ADRs before proposing a change that contradicts one; note ADR 0002 is still `Proposed`.
 - **[apps/docs/ai-pipeline/CONTRIBUTING.md](apps/docs/ai-pipeline/CONTRIBUTING.md)** — how a content edit reaches the documentation site, the MCP server, and the published Hopper agent Skill. See also [ADR 0002](docs/adr/0002-hopper-agent-skill.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ Accepted decision records. They own the rationale and the mechanism; the instruc
 
 - Build: `pnpm build:pkg`
 - Test: `pnpm test`
+- Lint: `pnpm lint`
 
 Turbo filters on the `name` field, not the directory: `@hopper-ui/components`, `@hopper-ui/icons`, `@hopper-ui/styled-system`, `@hopper-ui/svg-icons`, `@hopper-ui/tokens`, `@hopper-ui/mcp-server`, `docs`, `basic`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,20 @@ Claude Code attaches the rules below itself when it reads a matching file. Every
 | Any exported name, CSS class name, or `--hop-*` custom property                   | `docs/agents/versioning.md`             |
 | Naming a new `.ts`/`.tsx` file or a new component directory                       | `docs/agents/typescript.md`             |
 
+### Architecture decisions (MUST follow)
+
+Accepted decision records. They own the rationale and the mechanism; the instruction files above own the imperative.
+
+| Trigger                                                                       | Read                                                                              |
+| ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| A new interactive component, or hand-rolling ARIA, focus or keyboard behavior | [ADR 0003](docs/adr/0003-react-aria-is-the-primitive-foundation.md)               |
+| A hardcoded colour or length, or adding a token                               | [ADR 0004](docs/adr/0004-design-tokens-are-the-only-source-of-visual-values.md)   |
+| Style props, `UNSAFE_*`, or reaching for a CSS module                         | [ADR 0005](docs/adr/0005-styling-uses-style-props-and-native-css.md)              |
+| A stateful prop, a `default*` prop, or a controlled/uncontrolled pair         | [ADR 0006](docs/adr/0006-components-support-controlled-and-uncontrolled-modes.md) |
+| Naming a prop, an event handler, or a ref                                     | [ADR 0007](docs/adr/0007-component-api-naming-conventions.md)                     |
+| A class name, a token declaration, or a breaking change                       | [ADR 0008](docs/adr/0008-versioning-for-parallel-releases.md)                     |
+| Keyboard behavior, focus rings, or an accessible name                         | [ADR 0009](docs/adr/0009-accessibility-baseline.md)                               |
+
 ## Hard Rules (Non-Negotiable)
 
 | Rule                                                                                                                                                                  | Violation                                                   |
@@ -102,5 +116,5 @@ These three encode the workflows of this repository. The installed third-party s
 
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** — monorepo setup, installation, and the full command list. Packages must be built before anything runs.
 - **[contributing/](contributing/)** — human-facing guides for [tokens](contributing/tokens.md), [icons](contributing/icons.md) and [components](contributing/components.md).
-- **[docs/adr/](docs/adr/)** — architectural decisions. Consult existing ADRs before proposing a change that contradicts one; note ADR 0002 is still `Proposed`.
+- **[docs/adr/](docs/adr/)** — nine architectural decision records; 0003 through 0009 are indexed above. ADR 0002 is the only one still `Proposed`.
 - **[apps/docs/ai-pipeline/CONTRIBUTING.md](apps/docs/ai-pipeline/CONTRIBUTING.md)** — how a content edit reaches the documentation site, the MCP server, and the published Hopper agent Skill. See also [ADR 0002](docs/adr/0002-hopper-agent-skill.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,80 +1,97 @@
-# Repository Guidelines
+# AGENTS.md
 
-## Project Overview
+> Repo-wide guardrails + routing. Start here, then follow **Instruction routing** to the nearest scoped `AGENTS.md` and any additional instruction file that matches.
 
-- Package manager: `pnpm`
-- Type check: `pnpm tsc --noEmit`
-- Lint: `pnpm lint`
+## Instruction routing (read when relevant)
+
+### Path-based routing (MUST follow)
+
+| Path                                         | Read                                  |
+| -------------------------------------------- | ------------------------------------- |
+| `packages/<pkg>/**`                          | `packages/<pkg>/AGENTS.md` if present |
+| `apps/<app>/**`                              | `apps/<app>/AGENTS.md` if present     |
+| `packages/components/**`                     | `packages/components/AGENTS.md`       |
+| `packages/tokens/**`                         | `packages/tokens/AGENTS.md`           |
+| `packages/icons/**`, `packages/svg-icons/**` | `packages/icons/AGENTS.md`            |
+| `apps/docs/**`                               | `apps/docs/AGENTS.md`                 |
+
+Claude Code attaches the rules below by glob on its own. Every other agent MUST read the one whose path matches.
+
+| Path                                      | Read                             |
+| ----------------------------------------- | -------------------------------- |
+| `packages/components/src/**/*.module.css` | `.claude/rules/component-css.md` |
+| `packages/components/src/**/src/*.tsx`    | `.claude/rules/component-tsx.md` |
+| `packages/**/package.json`                | `.claude/rules/package-json.md`  |
+
+### Trigger-based routing (MUST follow)
+
+| Trigger                                                                                    | Read                                    |
+| ------------------------------------------------------------------------------------------ | --------------------------------------- |
+| A component's public API, props, slots, composition, defaults, or event callbacks          | `docs/agents/component-architecture.md` |
+| An exported name, a CSS class name, or a token custom property consumers already depend on | `docs/agents/versioning.md`             |
+| Naming a new `.ts`/`.tsx` file or a new component directory                                | `docs/agents/typescript.md`             |
+
+## Hard Rules (Non-Negotiable)
+
+| Rule                                                                                                             | Violation                                                        |
+| ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| ALWAYS run commands from the repo root                                                                           | `cd packages/components && npx vitest`                           |
+| NEVER run `tsc`, `oxlint`, `stylelint` or `vitest` directly inside a package                                     | `cd packages/tokens && npx tsc`                                  |
+| NEVER treat root `pnpm typecheck` as a package check — the root `tsconfig.json` excludes `packages` and `apps`   | Reporting types clean after `pnpm typecheck`                     |
+| MUST run `pnpm build:pkg` after installing and after changing a package's public API                             | Debugging an import error in an unbuilt workspace                |
+| MUST scope Turbo checks with `--filter`                                                                          | `turbo run typecheck` across every package for a one-file change |
+| NEVER add a decorative comment divider                                                                           | A row of dashes or box characters used to separate sections      |
+| ALWAYS flag an invented placeholder (URL, threshold, magic number, copy) with a `// TODO` naming what to confirm | A guessed `href="https://…"` presented as final                  |
+| ALWAYS prefer editing an existing file over creating a new one                                                   | A new utility file beside an existing one that fits              |
+
+## Build / Test / Lint
+
+- Build: `pnpm build:pkg`
 - Test: `pnpm test`
 
-## Use the token system
+After making changes, you MUST ALWAYS validate.
 
-Title: Use the token system
+| What you changed      | Run this                                                    | It must pass                                            |
+| --------------------- | ----------------------------------------------------------- | ------------------------------------------------------- |
+| A package source file | `pnpm build:pkg`                                            | Build succeeds                                          |
+| Logic or behavior     | `turbo run test --filter=<package>`                         | All unit tests pass                                     |
+| Code or types         | `turbo run typecheck --filter=<package>`                    | No type errors                                          |
+| CSS                   | `turbo run stylelint --filter=<package>`                    | No lint errors                                          |
+| `package.json`        | `pnpm syncpack`                                             | No dependency policy violations                         |
+| Formatting            | `pnpm format`                                               | Auto-fixes; `pnpm format:check` verifies                |
+| Design tokens         | `pnpm build:tokens`                                         | Generated CSS regenerates                               |
+| Docs content          | `pnpm doc:generate && pnpm build:doc && pnpm build:ai-docs` | The site and the AI surfaces both build                 |
+| Multiple categories   | `pnpm lint`                                                 | oxlint, format:check, stylelint, typecheck and syncpack |
 
-Description: Always use CSS variables from the token system instead of hardcoded values. The token system is defined in `packages/tokens/src/tokens/` and can be referenced in `packages/styled-system/src/tokens/tokenMappings.ts` and `packages/styled-system/src/tokens/tokens.ts`.
+## Workflow
 
-Tokens follow the pattern `var(--hop-[category]-[property])` such as:
+### Plan Mode
 
-- `var(--hop-neutral-text)`
-- `var(--hop-space-stack-md)`
-- `var(--hop-shape-rounded-md)`
+- Make the plan extremely concise. Sacrifice grammar for the sake of concision.
+- End each plan with the unresolved questions, if any.
 
-Component-specific tokens should reference these global tokens, e.g., `--hop-Button-background: var(--hop-neutral-surface)`.
+### Implementation Order
 
-Path patterns: packages/components/src/**/*.module.css
+Feature first → user confirms "Looks good" → then tests and stories. Never test before confirmation.
 
-## Never use component tokens outside their own component
+## Git/GitHub instructions
 
-Title: Never use component tokens outside their own component
-
-Description: Component tokens (`--hop-comp-<component-name>-*`) must only be used inside the CSS module of the component they belong to. Never reference a component token from a different component's CSS module — this makes token usage untraceable and breaks encapsulation.
-
-If another component needs a similar visual treatment, define a new token in that component's own token file (e.g., `avatar.tokens.json`) rather than borrowing from another component's tokens.
-
-Bad: using `var(--hop-comp-tooltip-color)` inside `AvatarGroup.module.css`
-Good: define `--hop-comp-avatar-description-color` in `avatar.tokens.json` and use it in `AvatarGroup.module.css`
-
-Path patterns: packages/components/src/**/*.module.css
-
-## Don't set style properties in context objects
-
-Title: Don't set style properties in context objects
-
-Description: Do not set style properties like `fontWeight`, `color`, or other visual attributes directly in context objects.
-These properties should be defined in CSS modules instead. For example, instead of `[HeadingContext, { fontWeight: "heading-xs-medium" }]`, define the font weight in the CSS module and only use `className` in the context object.
-
-Path patterns: packages/components/src/**/*.tsx
-
-## File naming conventions
-
-- Use **PascalCase** for files that contain:
-  - React components (e.g., `Button.tsx`, `IconButton.tsx`)
-  - Classes (e.g., `ValidationService.ts`, `TokenMapper.ts`)
-  - A single type/interface that matches the filename (e.g., `ButtonProps.ts`)
-- Use **camelCase** for all other files:
-  - Utility functions (e.g., `formatDate.ts`, `mergeProps.ts`)
-  - Configuration files (e.g., `tokenMappings.ts`, `cssVariables.ts`)
-  - Test files (e.g., `button.test.tsx`, `utils.test.ts`)
-  - Hooks (e.g., `useHover.ts`, `useScrollPosition.ts`)
-  - Constants, enums, and shared types (e.g., `colors.ts`, `breakpoints.ts`, `types.ts`)
-
-## Code style
-
-- Use double quotes for strings.
-- Use camelCase for variable and function names.
-- Use PascalCase for component names.
-- Use consistent indentation (4 spaces).
+- Branch name format: `<TICKET>-<kebab-description>`, e.g. `SGPD-9268-remove-tanstack-table`. Tickets are `SGPD-` or `SGPLTD-`.
+- Pull request title format: `[<TICKET>] <Title>`. Use a conventional-commit prefix (`fix:`, `feat(docs):`) only for a change with no ticket.
 
 ## Skills
 
-Hopper also publishes a consumer-facing agent Skill generated from `apps/docs` — see
-`apps/docs/ai-pipeline/CONTRIBUTING.md` and [ADR 0002](docs/adr/0002-hopper-agent-skill.md).
-Component and token content edits now propagate to three surfaces: the documentation site, the MCP
-server, and that published Skill. It is a build artifact and is not checked in, so it does not
-appear in the table below, which lists the skills used when working _in_ this repository.
+These three encode the workflows of this repository. The installed third-party skills (`accessibility`, `performance`, `pnpm`, `react-aria`, `turborepo`, `vitest`, `workleap-web-configs`) trigger on their own descriptions and need no row here.
 
 | Skill                 | When to use                                                                |
 | --------------------- | -------------------------------------------------------------------------- |
 | `update-tokens`       | Add, update, delete, or deprecate design tokens                            |
-| `learn-from-feedback` | Capture a developer correction into a skill or CLAUDE.md                   |
 | `port-component`      | Port a new component into Hopper from its React Spectrum S2 implementation |
+| `learn-from-feedback` | Capture a developer correction into a skill or an instruction file         |
+
+## Detailed Documentation
+
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** — monorepo setup, installation, and the full command list. Packages must be built before anything runs.
+- **[contributing/](contributing/)** — human-facing guides for [tokens](contributing/tokens.md), [icons](contributing/icons.md) and [components](contributing/components.md).
+- **[docs/adr/](docs/adr/)** — architectural decisions. Consult existing ADRs before proposing a change that contradicts one.
+- **[apps/docs/ai-pipeline/CONTRIBUTING.md](apps/docs/ai-pipeline/CONTRIBUTING.md)** — how a content edit reaches the documentation site, the MCP server, and the published Hopper agent Skill. See also [ADR 0002](docs/adr/0002-hopper-agent-skill.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md - docs
+
+A component or token content edit propagates to three surfaces: the documentation site, the MCP
+server, and the published Hopper agent Skill. Read `ai-pipeline/CONTRIBUTING.md` before changing
+anything under `ai-pipeline/`.
+
+## Hard Rules
+
+| Rule                                                                               | Violation                                                        |
+| ---------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| Run `pnpm doc:generate` before `pnpm doc:start` — previews do not exist until then | Starting the site and reporting missing component previews       |
+| Leave `.mdx` formatting alone — `oxfmt` skips it because reflow breaks JSX nesting | Hand-reflowing an `.mdx` paragraph to satisfy a line-width habit |
+
+## Layout
+
+| Path                       | Holds                                                  |
+| -------------------------- | ------------------------------------------------------ |
+| `content/`                 | MDX documentation, one folder per section              |
+| `ai-pipeline/`             | The generators for the AI docs and the published Skill |
+| `examples/`, `components/` | Site-only React used by the docs pages                 |

--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -1,20 +1,27 @@
 # AGENTS.md - docs
 
-A component or token content edit propagates to three surfaces: the documentation site, the MCP
-server, and the published Hopper agent Skill. Read `ai-pipeline/CONTRIBUTING.md` before changing
-anything under `ai-pipeline/`.
+A content edit under `content/` propagates to three surfaces: the documentation site, the MCP server,
+and the published Hopper agent Skill. Read `ai-pipeline/CONTRIBUTING.md` before adding a route to
+`ai-pipeline/ai-docs.config.tsx`.
 
 ## Hard Rules
 
-| Rule                                                                               | Violation                                                        |
-| ---------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| Run `pnpm doc:generate` before `pnpm doc:start` — previews do not exist until then | Starting the site and reporting missing component previews       |
-| Leave `.mdx` formatting alone — `oxfmt` skips it because reflow breaks JSX nesting | Hand-reflowing an `.mdx` paragraph to satisfy a line-width habit |
+| Rule                                                                                | Violation                                                                               |
+| ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Run `pnpm doc:generate` before `pnpm doc:start`                                     | A module-resolution failure on `examples/Preview.ts`, which is generated and gitignored |
+| Verify a content edit with `pnpm build:doc` — it chains generate → ai-docs → skills | Checking the website only and calling the change done                                   |
+| Treat `components/mdx/*.ai.tsx` as pipeline code, not site code                     | Restyling it as if only the website rendered it                                         |
+| Leave `.mdx` formatting alone — `oxfmt` skips it because reflow breaks JSX nesting  | Hand-reflowing an `.mdx` paragraph to satisfy a line-width habit                        |
 
 ## Layout
 
-| Path                       | Holds                                                  |
-| -------------------------- | ------------------------------------------------------ |
-| `content/`                 | MDX documentation, one folder per section              |
-| `ai-pipeline/`             | The generators for the AI docs and the published Skill |
-| `examples/`, `components/` | Site-only React used by the docs pages                 |
+| Path           | Holds                                                                          |
+| -------------- | ------------------------------------------------------------------------------ |
+| `content/`     | 134 MDX docs plus one plain `.md`, one folder per section                      |
+| `app/`         | The site itself                                                                |
+| `scripts/`     | The AI-docs and Skill generators (`buildAiDocs.ts`, `buildSkills.ts`)          |
+| `ai-pipeline/` | Config, templates, and the scripts bundled _into_ the Skill                    |
+| `components/`  | Site React — and `components/mdx/*.ai.tsx`, which the AI pipeline renders with |
+| `examples/`    | Overview SVG assets and the generated `Preview.ts` registry                    |
+
+Preview sources are not here — they resolve to `packages/components/src/**` and `packages/icons/**`.

--- a/docs/agents/component-architecture.md
+++ b/docs/agents/component-architecture.md
@@ -1,42 +1,80 @@
 # Component Architecture
 
+[ADR 0003](../adr/0003-react-aria-is-the-primitive-foundation.md),
+[ADR 0006](../adr/0006-components-support-controlled-and-uncontrolled-modes.md) and
+[ADR 0007](../adr/0007-component-api-naming-conventions.md) own the reasoning behind this file.
+
 ## Hard Rules
 
 | Rule                                                                                                                          | Violation                                             |
 | ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| Start a new interactive component from React Aria Components or its hooks                                                     | A `div` with an `onClick` and a `role`                |
+| Let React Aria own focus traps, roving tabindex, type-ahead and ARIA wiring                                                   | Hand-rolling any of them                              |
 | Expose styling props, an appendable `className` and a `ref` on the root element                                               | Skipping `useStyledSystem` in a new component         |
 | Name a prop bag after the child it lands on — `<child>Props`                                                                  | A bespoke `extraProps` for the inner input            |
 | Reuse the shared placeholders for slot content                                                                                | A component-specific `CardHeader` instead of `Header` |
 | Ship brand defaults so a consumer sets as few props as possible                                                               | A required `variant` prop                             |
 | Set a child's appearance from the parent through `SlotProvider` and the child's context                                       | Leaving the consumer to style a composed child        |
+| Expose `default*` alongside the controlled prop on a stateful component                                                       | A controlled-only prop pair on something new          |
+| Route state through `useControlledState`, or the React Aria state hook that wraps it                                          | Hand-writing the controlled/uncontrolled branch       |
 | Leave `stopPropagation` alone; with react-aria's `useKeyboard`, call `event.continuePropagation()` for keys you do not handle | Swallowing `Escape` without meaning to                |
 
+`InputGroup` calls `preventDefault` deliberately, to forward focus to its inner input — the one
+sanctioned exception. `ActionBar` is the only `useKeyboard` site, and the only controlled-only
+component. Mixing modes on one prop is a silent bug: the controlled prop wins and `default*` is
+ignored, with no React warning, because React never sees these props.
+
+## Naming
+
+| Kind                       | Convention                                 | Never                         |
+| -------------------------- | ------------------------------------------ | ----------------------------- |
+| Boolean                    | `isOpen`, `isDisabled`, `isFluid`          | `open`, `disabled`            |
+| Event handler              | `onPress`, `onChange`, `onSelectionChange` | `onClick`                     |
+| Uncontrolled initial value | `defaultOpen`, `defaultValue`              | `initialOpen`                 |
+| Element swap               | `elementType`                              | `as`, `component`, `renderAs` |
+| Outer element ref          | `ref`                                      | `rootRef`, `containerRef`     |
+
+`as` exists on `Box` alone; named inner refs (`inputRef`, `inputStartRef`) are deliberate where there
+are several focusable targets. `onPress` receives a React Aria `PressEvent`, not a native event.
+
+Read prop names from `packages/components/src/<group>/src/<Component>.tsx` — TypeScript is
+authoritative. The generated API JSON under `apps/docs/dist/ai-docs/` is a build artifact and is wrong
+for `Select`, `MultiSelect` and `ComboBox`.
+
+## Styling escalation
+
+Style props first, then an `UNSAFE_*` prop, then a CSS module. `UNSAFE_*` is a whitelist of specific
+props, not a universal prefix — see [ADR 0005](../adr/0005-styling-uses-style-props-and-native-css.md)
+before reaching for it. `UNSAFE_className` and `UNSAFE_style` do not exist.
+
+## Composition
+
 The shared placeholders are `Header` (`header/`), `Content` and `Footer` (`layout/`), and `Text`
-(`typography/text/`), reused through their contexts in 27, 8, 8 and 3 files. `DisclosureHeader` and
-`CalendarHeader` are the sanctioned exceptions — a header carrying its own interactive behavior.
+(`typography/text/`). `DisclosureHeader` and `CalendarHeader` are the sanctioned exceptions — a header
+carrying its own interactive behavior. A wrapper is a normal composition unit (`CheckboxField`,
+`PopoverTrigger`); what to avoid is a wrapper whose only purpose is renaming props.
 
 `Callout` is the worked example for parent-driven appearance: it wraps children in a `SlotProvider`
-that sets `ButtonContext` and `LinkButtonContext` to `variant: "secondary"`. `Popover`, `Accordion`,
+setting `ButtonContext` and `LinkButtonContext` to `variant: "secondary"`. `Popover`, `Accordion`,
 `Modal`, `ComboBox` and `Select` do the same. `Card` does **not** — it wires no context at all, so
 treat it as a gap rather than a pattern to copy.
 
 ## Goals for new API surface
 
-These hold for anything new. Existing components diverge, so do not "fix" the named cases — several
-are locked in by public types and would be breaking changes.
+These hold for anything new. Existing components diverge; do not "fix" the named cases, as several are
+locked in by public types and would be breaking changes.
 
-| Goal                                                           | Where the codebase diverges                                                                                           |
-| -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| Give a wrapper or nested element a prop bag and a `ref`        | 8 components render an internal wrapper exposing nothing, incl. `Popover`, `Radio`, `Checkbox`, `Tile`, `ListBoxItem` |
-| Give every native and react-aria event a callback prop         | `MenuTrigger` wires an internal `onPressStart` a consumer cannot observe                                              |
-| Forward the original event arguments to the consumer's handler | `Alert`'s three `on*ButtonClick` props and `TextField.onClear` are typed `() => void`                                 |
-| Take rendered content as children in a slot, not as a prop     | 18 shipped `ReactNode` props, incl. `prefix`, `footer`, `icon`, `description`                                         |
+| Goal                                                           | Where the codebase diverges                                                                |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Give a wrapper or nested element a prop bag and a `ref`        | 8 components render an internal wrapper exposing nothing, incl. `Popover`, `Radio`, `Tile` |
+| Give every native and react-aria event a callback prop         | `MenuTrigger` wires an internal `onPressStart` a consumer cannot observe                   |
+| Forward the original event arguments to the consumer's handler | `Alert`'s three `on*ButtonClick` props and `TextField.onClear` are typed `() => void`      |
+| Take rendered content as children in a slot, not as a prop     | 18 shipped `ReactNode` props, incl. `prefix`, `footer`, `icon`                             |
 
 ## Mobile
 
 Where the native mobile experience diverges sharply from the web one, add a sibling built on the
-native element to `packages/styled-system/src/html-wrappers/html.ts`, rather than emulating native
-behavior inside the richer component. A name that collides with a Hopper component takes an `Html`
-prefix — `HtmlButton`, `HtmlHeader` — so a native select would be `HtmlSelect`. None exists yet.
+native element to `packages/styled-system/src/html-wrappers/html.ts`. A name colliding with a Hopper
+component takes an `Html` prefix — so a native select would be `HtmlSelect`. None exists yet.
 
 `packages/components/src/html-elements/` is documentation previews only; nothing there is exported.

--- a/docs/agents/component-architecture.md
+++ b/docs/agents/component-architecture.md
@@ -1,0 +1,44 @@
+# Component Architecture
+
+## Hard Rules
+
+| Rule                                                                                                                               | Violation                                                     |
+| ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Expose styling props, an appendable `className` and a `ref` on the root, the wrapper, and any nested element a consumer must reach | A wrapper element with no prop bag and no `ref`               |
+| Give every native and react-aria event a callback prop                                                                             | An internal `onKeyDown` a consumer cannot observe             |
+| Forward the original event arguments to the consumer's handler                                                                     | `onPress={() => props.onPress?.()}` — drops the event         |
+| Let events keep propagating                                                                                                        | `e.stopPropagation()` inside a component's own handler        |
+| Accept rendered content as children in a slot                                                                                      | `<Button icon={<BellIcon />} label="Notify" />`               |
+| Reuse the shared placeholder components for slot content                                                                           | A component-specific `CardHeader` instead of `Header`         |
+| Ship brand defaults so a consumer sets as few props as possible                                                                    | Requiring `variant` on every `Button`                         |
+| Let the parent decide a child's appearance inside a composition                                                                    | A `Card` whose consumer must set the inner `Button`'s variant |
+
+## Overridability
+
+Ref and prop access to inner elements goes through the established prop-bag pattern —
+`wrapperProps`, `overlayProps`, `popoverProps` — rather than a new bespoke prop per component.
+
+## Composition over configuration
+
+Keep structure decoupled from contents so contents can be swapped without touching the component.
+
+```tsx
+<Button>
+  <BellIcon />
+  <Text>Notify</Text>
+</Button>
+```
+
+The shared placeholders are `Header` (`header/`), `Content` and `Footer` (`layout/`), and `Text`
+(`typography/text/`). Collection content reuses the owning component's `*Item` / `*Section` exports.
+
+## Brand defaults
+
+Hopper is a design system, not an opinionless library. Defaults encode brand decisions, so a brand
+update becomes a change of defaults here rather than a change in every consumer's code.
+
+## Mobile
+
+Where the native mobile experience diverges sharply from the web one, add a sibling component built
+on the native element next to the existing native wrappers in `packages/components/src/html-elements/`,
+rather than emulating native mobile behavior inside the richer component.

--- a/docs/agents/component-architecture.md
+++ b/docs/agents/component-architecture.md
@@ -2,43 +2,41 @@
 
 ## Hard Rules
 
-| Rule                                                                                                                               | Violation                                                     |
-| ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| Expose styling props, an appendable `className` and a `ref` on the root, the wrapper, and any nested element a consumer must reach | A wrapper element with no prop bag and no `ref`               |
-| Give every native and react-aria event a callback prop                                                                             | An internal `onKeyDown` a consumer cannot observe             |
-| Forward the original event arguments to the consumer's handler                                                                     | `onPress={() => props.onPress?.()}` — drops the event         |
-| Let events keep propagating                                                                                                        | `e.stopPropagation()` inside a component's own handler        |
-| Accept rendered content as children in a slot                                                                                      | `<Button icon={<BellIcon />} label="Notify" />`               |
-| Reuse the shared placeholder components for slot content                                                                           | A component-specific `CardHeader` instead of `Header`         |
-| Ship brand defaults so a consumer sets as few props as possible                                                                    | Requiring `variant` on every `Button`                         |
-| Let the parent decide a child's appearance inside a composition                                                                    | A `Card` whose consumer must set the inner `Button`'s variant |
-
-## Overridability
-
-Ref and prop access to inner elements goes through the established prop-bag pattern —
-`wrapperProps`, `overlayProps`, `popoverProps` — rather than a new bespoke prop per component.
-
-## Composition over configuration
-
-Keep structure decoupled from contents so contents can be swapped without touching the component.
-
-```tsx
-<Button>
-  <BellIcon />
-  <Text>Notify</Text>
-</Button>
-```
+| Rule                                                                                                                          | Violation                                             |
+| ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| Expose styling props, an appendable `className` and a `ref` on the root element                                               | Skipping `useStyledSystem` in a new component         |
+| Name a prop bag after the child it lands on — `<child>Props`                                                                  | A bespoke `extraProps` for the inner input            |
+| Reuse the shared placeholders for slot content                                                                                | A component-specific `CardHeader` instead of `Header` |
+| Ship brand defaults so a consumer sets as few props as possible                                                               | A required `variant` prop                             |
+| Set a child's appearance from the parent through `SlotProvider` and the child's context                                       | Leaving the consumer to style a composed child        |
+| Leave `stopPropagation` alone; with react-aria's `useKeyboard`, call `event.continuePropagation()` for keys you do not handle | Swallowing `Escape` without meaning to                |
 
 The shared placeholders are `Header` (`header/`), `Content` and `Footer` (`layout/`), and `Text`
-(`typography/text/`). Collection content reuses the owning component's `*Item` / `*Section` exports.
+(`typography/text/`), reused through their contexts in 27, 8, 8 and 3 files. `DisclosureHeader` and
+`CalendarHeader` are the sanctioned exceptions — a header carrying its own interactive behavior.
 
-## Brand defaults
+`Callout` is the worked example for parent-driven appearance: it wraps children in a `SlotProvider`
+that sets `ButtonContext` and `LinkButtonContext` to `variant: "secondary"`. `Popover`, `Accordion`,
+`Modal`, `ComboBox` and `Select` do the same. `Card` does **not** — it wires no context at all, so
+treat it as a gap rather than a pattern to copy.
 
-Hopper is a design system, not an opinionless library. Defaults encode brand decisions, so a brand
-update becomes a change of defaults here rather than a change in every consumer's code.
+## Goals for new API surface
+
+These hold for anything new. Existing components diverge, so do not "fix" the named cases — several
+are locked in by public types and would be breaking changes.
+
+| Goal                                                           | Where the codebase diverges                                                                                           |
+| -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Give a wrapper or nested element a prop bag and a `ref`        | 8 components render an internal wrapper exposing nothing, incl. `Popover`, `Radio`, `Checkbox`, `Tile`, `ListBoxItem` |
+| Give every native and react-aria event a callback prop         | `MenuTrigger` wires an internal `onPressStart` a consumer cannot observe                                              |
+| Forward the original event arguments to the consumer's handler | `Alert`'s three `on*ButtonClick` props and `TextField.onClear` are typed `() => void`                                 |
+| Take rendered content as children in a slot, not as a prop     | 18 shipped `ReactNode` props, incl. `prefix`, `footer`, `icon`, `description`                                         |
 
 ## Mobile
 
-Where the native mobile experience diverges sharply from the web one, add a sibling component built
-on the native element next to the existing native wrappers in `packages/components/src/html-elements/`,
-rather than emulating native mobile behavior inside the richer component.
+Where the native mobile experience diverges sharply from the web one, add a sibling built on the
+native element to `packages/styled-system/src/html-wrappers/html.ts`, rather than emulating native
+behavior inside the richer component. A name that collides with a Hopper component takes an `Html`
+prefix — `HtmlButton`, `HtmlHeader` — so a native select would be `HtmlSelect`. None exists yet.
+
+`packages/components/src/html-elements/` is documentation previews only; nothing there is exported.

--- a/docs/agents/typescript.md
+++ b/docs/agents/typescript.md
@@ -2,15 +2,27 @@
 
 ## File Naming
 
-| Contents                                         | Convention                  | Example                                  |
-| ------------------------------------------------ | --------------------------- | ---------------------------------------- |
-| React component                                  | PascalCase                  | `Button.tsx`, `IconButton.tsx`           |
-| Class                                            | PascalCase                  | `ValidationService.ts`                   |
-| A single type or interface matching the filename | PascalCase                  | `ButtonProps.ts`                         |
-| Utility function                                 | camelCase                   | `formatDate.ts`, `mergeProps.ts`         |
-| Configuration                                    | camelCase                   | `tokenMappings.ts`                       |
-| Hook                                             | camelCase                   | `useHover.ts`                            |
-| Constants, enums, shared types                   | camelCase                   | `colors.ts`, `breakpoints.ts`            |
-| Test                                             | Matches the unit under test | `Button.test.tsx`, `useDebounce.test.ts` |
+Every example below is a real file in this repo.
 
-Component directories under `packages/components/src/` are kebab-case — `action-bar/`, `list-box/`.
+| Contents              | Convention                     | Example                                  |
+| --------------------- | ------------------------------ | ---------------------------------------- |
+| React component       | PascalCase                     | `LinkButton.tsx`, `CloseButton.tsx`      |
+| A component's context | PascalCase, `<Name>Context.ts` | `ButtonContext.ts`                       |
+| Utility function      | camelCase                      | `cssModule.ts`, `omitProps.ts`           |
+| Hook                  | camelCase                      | `useDebounce.ts`, `useSlot.ts`           |
+| Configuration         | camelCase                      | `tokenMappings.ts`                       |
+| Shared types          | camelCase                      | `types.ts`, `styledSystemProps.ts`       |
+| Test                  | Matches the unit under test    | `Button.test.tsx`, `useDebounce.test.ts` |
+
+A component's props interface lives inside the component file — `export interface ComboBoxProps` in
+`ComboBox.tsx` — not in a standalone `*Props.ts`.
+
+Two accepted deviations: `Breakpoints.ts` is PascalCase despite exporting constants, and
+`Badge.utils.ts` / `Tag.utils.ts` use a PascalCase `<Name>.utils.ts` form.
+
+## Directories
+
+Component directories under `packages/components/src/` are kebab-case — `action-bar/`, `list-box/` —
+and hold a component _group_, not one component each. `buttons/`, `inputs/`, `layout/`, `overlays/`
+and `typography/` each hold several. `combobox/` is the one name that does not kebab its component
+(`ComboBox`).

--- a/docs/agents/typescript.md
+++ b/docs/agents/typescript.md
@@ -1,0 +1,16 @@
+# TypeScript Conventions
+
+## File Naming
+
+| Contents                                         | Convention                  | Example                                  |
+| ------------------------------------------------ | --------------------------- | ---------------------------------------- |
+| React component                                  | PascalCase                  | `Button.tsx`, `IconButton.tsx`           |
+| Class                                            | PascalCase                  | `ValidationService.ts`                   |
+| A single type or interface matching the filename | PascalCase                  | `ButtonProps.ts`                         |
+| Utility function                                 | camelCase                   | `formatDate.ts`, `mergeProps.ts`         |
+| Configuration                                    | camelCase                   | `tokenMappings.ts`                       |
+| Hook                                             | camelCase                   | `useHover.ts`                            |
+| Constants, enums, shared types                   | camelCase                   | `colors.ts`, `breakpoints.ts`            |
+| Test                                             | Matches the unit under test | `Button.test.tsx`, `useDebounce.test.ts` |
+
+Component directories under `packages/components/src/` are kebab-case — `action-bar/`, `list-box/`.

--- a/docs/agents/versioning.md
+++ b/docs/agents/versioning.md
@@ -1,0 +1,23 @@
+# Versioning
+
+Hopper packages are shared dependencies of Module Federation applications, so two versions must be
+able to coexist in one page while an update rolls out.
+
+## Hard Rules
+
+| Rule                                                                                          | Violation                                                           |
+| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Keep a release backwards compatible; ship a compatibility package when a break is unavoidable | Renaming an exported prop in a minor                                |
+| Carry styles on the hashed CSS-module class, via `cssModule(styles, "hop-Name", ...)`         | Writing style declarations against the unhashed `hop-Name` selector |
+| Keep the `Global<Name>CssSelector` export an addressable hook only                            | Two versions both styling the same global `.hop-Button`             |
+| Scope token custom properties per remote module, or hash them per release                     | A single global `--hop-*` value two versions overwrite              |
+| Treat reliance on a single unscoped global CSS name as a breaking change                      | Shipping it as a patch                                              |
+
+## The two class names
+
+Each component emits both, and the split is what makes parallel versions safe:
+
+| Class                           | Hashed | Purpose                                                 |
+| ------------------------------- | ------ | ------------------------------------------------------- |
+| `cssModule(styles, "hop-Name")` | Yes    | Carries every style declaration                         |
+| `Global<Name>CssSelector`       | No     | Lets a consumer target the component; carries no styles |

--- a/docs/agents/versioning.md
+++ b/docs/agents/versioning.md
@@ -1,44 +1,42 @@
 # Versioning
 
 Hopper's consuming applications run Module Federation — this repo does not — so two Hopper versions
-must be able to coexist in one page while an update rolls out. That constraint is why class names and
-token declarations are version-stamped.
+must coexist in one page while an update rolls out. That is why class names and token declarations are
+version-stamped. [ADR 0008](../adr/0008-versioning-for-parallel-releases.md) records the mechanism and
+the reasoning; the rules below are what to do about it.
 
 ## Hard Rules
 
-| Rule                                                                                                                              | Violation                                          |
-| --------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| Carry every style declaration on the hashed CSS-module class, via `cssModule(styles, "hop-Name", ...)`                            | A rule targeting the unhashed `.hop-Name` selector |
-| Keep the `Global<Name>CssSelector` export an addressable hook that carries no styles                                              | Adding a `:global(.hop-Button)` rule               |
-| Emit token declarations under the version-stamped root class                                                                      | A new `:root` block of `--hop-*` values            |
-| Absorb a breaking change into a major, with a changeset naming the migration and an `UNSAFE_*` escape hatch where one is possible | Shipping it as a minor                             |
+| Rule                                                                                                                              | Violation                                                                                            |
+| --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Carry every style declaration on the hashed CSS-module class, via `cssModule(styles, "hop-Name", ...)`                            | A rule targeting the unhashed `.hop-Name` selector                                                   |
+| Keep the `Global<Name>CssSelector` export an addressable hook that carries no styles                                              | Adding a `:global(.hop-Button)` rule                                                                 |
+| Assert against the exported `Global<Name>CssSelector` in tests — `expect(el).toHaveClass("hop-Button")`                           | Asserting the hashed ident `hop-Button___3-3-0___vWScb`, or a descendant class                       |
+| Emit token declarations under the version-stamped root class                                                                      | A new `:root` block of `--hop-*` values                                                              |
+| Read a `--hop-*` variable only where a Hopper provider is an ancestor; portaled content needs the root class on its container     | Reading a token in content rendered outside the provider subtree, where it silently will not resolve |
+| Leave `BodyStyleProvider` to bridge `<body>`, which sits outside the provider subtree                                             | "Simplifying" it by hardcoding token references onto `body`                                          |
+| Preserve the version interpolation in `tooling/rslib-config/defineHopperRslibConfig.ts`                                           | "Correcting" it to a plain content hash                                                              |
+| Absorb a breaking change into a major, with a changeset naming the migration and an `UNSAFE_*` escape hatch where one is possible | Shipping it as a minor                                                                               |
 
-Nothing currently styles an unhashed class — `:global(` appears zero times in component CSS. No lint
-rule enforces that, so this is convention only.
-
-## How isolation actually works
-
-Two independent mechanisms, both keyed on the package version:
-
-| What                    | Mechanism                                                                                                                                                                                                                                                                  |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CSS-module class names  | `localIdentName: [local]___<version>___[hash:base64:5]` in `tooling/rslib-config/defineHopperRslibConfig.ts` — so `hop-Button` ships as `hop-Button___3-3-0___a1b2c`. Version-stamped _and_ content-hashed; the version segment is what guarantees cross-release isolation |
-| Token custom properties | Declared under a root class, not hashed. `StyledSystemRootCssClass` is `hop-<version>`, and the theme sheet is emitted at `.hop-5-3-11-workleap`. The property _names_ stay global `--hop-*` by design                                                                     |
-
-Token isolation therefore depends on cascade proximity: sibling providers that share a descendant
-still collide. Two outputs are also genuinely unscoped — the dark-mode block emitted at
-`[data-mode="dark"]`, and the tokens package's own `dist/<brand>/tokens.css`, which lands at `:root`.
+Nothing currently styles an unhashed class — `:global(` appears zero times in component CSS — and
+`tooling/vitest-config` sets `classNameStrategy: "non-scoped"` so the assertions above work. No lint
+rule enforces any of this; it is convention only.
 
 ## The two class names
 
-| Class                           | Hashed | Emitted by                                        |
-| ------------------------------- | ------ | ------------------------------------------------- |
-| `Global<Name>CssSelector`       | No     | Every component                                   |
-| `cssModule(styles, "hop-Name")` | Yes    | Components that have their own styles — 88 of 102 |
+| Class                           | Hashed | Emitted by                 |
+| ------------------------------- | ------ | -------------------------- |
+| `Global<Name>CssSelector`       | No     | 102 of 116 component files |
+| `cssModule(styles, "hop-Name")` | Yes    | 89 of those 102            |
 
-The 14 that emit only the unhashed selector are the style-free shared placeholders (`Header`,
-`Content`, `Footer`, `Box`, the avatar fallbacks). That is by design, not a gap.
+The 13 with a selector but no styles are the shared placeholders and triggers — `Header`, `Content`,
+`Footer`, `Box`, the avatar fallbacks, `MenuTrigger`, `TooltipTrigger`. The 14 with no selector at all
+are listed in `packages/components/AGENTS.md`. Both sets are deliberate.
 
-No compatibility package exists today. The worked precedent is `@hopper-ui/components@3.0.0`, which
-restricted the `letterSpacing` styled-system prop to the new token scale and pointed consumers at
-`UNSAFE_letterSpacing`.
+Token isolation depends on cascade proximity, so sibling providers sharing a descendant still collide.
+Two outputs are genuinely unscoped: the dark-mode block emitted at `[data-mode="dark"]`, and the tokens
+package's own `dist/<brand>/tokens.css`, which lands at `:root`.
+
+No compatibility package exists. Breaking changes have shipped both ways — `@hopper-ui/components`
+3.0.0 restricted the `letterSpacing` style prop and offered `UNSAFE_letterSpacing`, while 3.3.0 removed
+an `ActionBar` prop in a _minor_. Follow the rule above rather than the 3.3.0 precedent.

--- a/docs/agents/versioning.md
+++ b/docs/agents/versioning.md
@@ -1,23 +1,44 @@
 # Versioning
 
-Hopper packages are shared dependencies of Module Federation applications, so two versions must be
-able to coexist in one page while an update rolls out.
+Hopper's consuming applications run Module Federation — this repo does not — so two Hopper versions
+must be able to coexist in one page while an update rolls out. That constraint is why class names and
+token declarations are version-stamped.
 
 ## Hard Rules
 
-| Rule                                                                                          | Violation                                                           |
-| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| Keep a release backwards compatible; ship a compatibility package when a break is unavoidable | Renaming an exported prop in a minor                                |
-| Carry styles on the hashed CSS-module class, via `cssModule(styles, "hop-Name", ...)`         | Writing style declarations against the unhashed `hop-Name` selector |
-| Keep the `Global<Name>CssSelector` export an addressable hook only                            | Two versions both styling the same global `.hop-Button`             |
-| Scope token custom properties per remote module, or hash them per release                     | A single global `--hop-*` value two versions overwrite              |
-| Treat reliance on a single unscoped global CSS name as a breaking change                      | Shipping it as a patch                                              |
+| Rule                                                                                                                              | Violation                                          |
+| --------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| Carry every style declaration on the hashed CSS-module class, via `cssModule(styles, "hop-Name", ...)`                            | A rule targeting the unhashed `.hop-Name` selector |
+| Keep the `Global<Name>CssSelector` export an addressable hook that carries no styles                                              | Adding a `:global(.hop-Button)` rule               |
+| Emit token declarations under the version-stamped root class                                                                      | A new `:root` block of `--hop-*` values            |
+| Absorb a breaking change into a major, with a changeset naming the migration and an `UNSAFE_*` escape hatch where one is possible | Shipping it as a minor                             |
+
+Nothing currently styles an unhashed class — `:global(` appears zero times in component CSS. No lint
+rule enforces that, so this is convention only.
+
+## How isolation actually works
+
+Two independent mechanisms, both keyed on the package version:
+
+| What                    | Mechanism                                                                                                                                                                                                                                                                  |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CSS-module class names  | `localIdentName: [local]___<version>___[hash:base64:5]` in `tooling/rslib-config/defineHopperRslibConfig.ts` — so `hop-Button` ships as `hop-Button___3-3-0___a1b2c`. Version-stamped _and_ content-hashed; the version segment is what guarantees cross-release isolation |
+| Token custom properties | Declared under a root class, not hashed. `StyledSystemRootCssClass` is `hop-<version>`, and the theme sheet is emitted at `.hop-5-3-11-workleap`. The property _names_ stay global `--hop-*` by design                                                                     |
+
+Token isolation therefore depends on cascade proximity: sibling providers that share a descendant
+still collide. Two outputs are also genuinely unscoped — the dark-mode block emitted at
+`[data-mode="dark"]`, and the tokens package's own `dist/<brand>/tokens.css`, which lands at `:root`.
 
 ## The two class names
 
-Each component emits both, and the split is what makes parallel versions safe:
+| Class                           | Hashed | Emitted by                                        |
+| ------------------------------- | ------ | ------------------------------------------------- |
+| `Global<Name>CssSelector`       | No     | Every component                                   |
+| `cssModule(styles, "hop-Name")` | Yes    | Components that have their own styles — 88 of 102 |
 
-| Class                           | Hashed | Purpose                                                 |
-| ------------------------------- | ------ | ------------------------------------------------------- |
-| `cssModule(styles, "hop-Name")` | Yes    | Carries every style declaration                         |
-| `Global<Name>CssSelector`       | No     | Lets a consumer target the component; carries no styles |
+The 14 that emit only the unhashed selector are the style-free shared placeholders (`Header`,
+`Content`, `Footer`, `Box`, the avatar fallbacks). That is by design, not a gap.
+
+No compatibility package exists today. The worked precedent is `@hopper-ui/components@3.0.0`, which
+restricted the `letterSpacing` styled-system prop to the new token scale and pointed consumers at
+`UNSAFE_letterSpacing`.

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -64,3 +64,9 @@ Some groups also carry `utils/`, `hooks/` or `assets/` siblings.
 
 The axe runner is local-only. Run `pnpm storybook-nolazy` in one terminal and `pnpm test-storybook`
 in another — the lazy-loading variant is incompatible with the runner. See `contributing/components.md`.
+
+Chromatic is not an accessibility signal — a green build says nothing about keyboard operability or
+screen reader output, so never cite it as evidence. The axe pass also excludes contrast, and
+`test-storybook` is not in CI, so nothing about accessibility gates a PR. The baseline is WCAG 2.2 AA
+with the WAI-ARIA Authoring Practices as the behavior reference; see
+[ADR 0009](../../docs/adr/0009-accessibility-baseline.md).

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md - components
+
+## Hard Rules
+
+| Rule                                                                                            | Violation                                               |
+| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| Export a `Global<Name>CssSelector` constant for every component                                 | A component consumers have no stable selector to target |
+| Merge props and ref with the component's context through `useContextProps` first                | Reading `props` directly and skipping the context merge |
+| Strip styling props with `useStyledSystem` before destructuring the component's own props       | Spreading style props onto the DOM element              |
+| Spread the consumer's `style` after `stylingProps.style` so the consumer wins                   | `{ ...style, ...stylingProps.style }`                   |
+| Add copy to `src/i18n/intl/en-US.json` and `fr-CA.json`, then read it with `useLocalizedString` | A hardcoded English string inside a component           |
+
+## Construction order
+
+```tsx
+[props, ref] = useContextProps(props, ref, ButtonContext);
+const { stylingProps, ...ownProps } = useStyledSystem(props);
+const { children, style, className, slot, ...otherProps } = ownProps;
+
+const classNames = clsx(className, GlobalButtonCssSelector, cssModule(styles, "hop-Button"), stylingProps.className);
+const mergedStyles: CSSProperties = { ...stylingProps.style, ...style };
+```
+
+A component with a default slot passes it in: `useContextProps({ ...props, slot: props.slot || DefaultIconListSlot }, ref, IconListContext)`.
+
+## Folder layout
+
+Each component group is a kebab-case directory under `src/`.
+
+| Path                       | Holds                                                                        |
+| -------------------------- | ---------------------------------------------------------------------------- |
+| `<group>/src/`             | `Component.tsx`, `Component.module.css`, `ComponentContext.ts` in PascalCase |
+| `<group>/tests/vitest/`    | `*.test.tsx` and `*.ssr.test.tsx`                                            |
+| `<group>/tests/chromatic/` | `*.stories.tsx`                                                              |
+| `<group>/docs/`            | Per-component doc folders and `migration-notes*.md`                          |
+| `<group>/index.ts`         | Barrel re-export                                                             |
+
+## Accessibility checks
+
+The axe runner is local-only. Run `pnpm storybook-nolazy` in one terminal and `pnpm test-storybook`
+in another — the lazy-loading variant is incompatible with the runner.

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -2,40 +2,65 @@
 
 ## Hard Rules
 
-| Rule                                                                                            | Violation                                               |
-| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| Export a `Global<Name>CssSelector` constant for every component                                 | A component consumers have no stable selector to target |
-| Merge props and ref with the component's context through `useContextProps` first                | Reading `props` directly and skipping the context merge |
-| Strip styling props with `useStyledSystem` before destructuring the component's own props       | Spreading style props onto the DOM element              |
-| Spread the consumer's `style` after `stylingProps.style` so the consumer wins                   | `{ ...style, ...stylingProps.style }`                   |
-| Add copy to `src/i18n/intl/en-US.json` and `fr-CA.json`, then read it with `useLocalizedString` | A hardcoded English string inside a component           |
+| Rule                                                                                                                                        | Violation                                                              |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Merge props and ref with the component's context through `useContextProps` first                                                            | Reading `props` directly and skipping the context merge                |
+| Strip styling props with `useStyledSystem` before destructuring the component's own props                                                   | Spreading style props onto the DOM element                             |
+| Export a `Global<Name>CssSelector` for every component that renders its own DOM element                                                     | A new styled component with no stable selector to target               |
+| Compose the class name from all four parts: the consumer's `className`, the global selector, the module class, and `stylingProps.className` | Dropping `stylingProps.className`, which silently disables style props |
+| Register a default slot with the `slot()` HOC at export                                                                                     | Trying to pass a default slot into `useContextProps`                   |
+| Add copy to `src/i18n/intl/en-US.json` and `fr-CA.json`, then read it with `useLocalizedString`                                             | A hardcoded English string inside a component                          |
+
+Trigger and provider components (`*Trigger`, `ClearSlots`) and the layout wrappers over `Box`
+(`Flex`, `Grid`, `Inline`, `Stack`) ship no selector of their own — 14 of 116 files, by design.
 
 ## Construction order
 
 ```tsx
-[props, ref] = useContextProps(props, ref, ButtonContext);
-const { stylingProps, ...ownProps } = useStyledSystem(props);
-const { children, style, className, slot, ...otherProps } = ownProps;
+import { slot as slotFn, useStyledSystem } from "@hopper-ui/styled-system";
+import clsx from "clsx";
+import { type CSSProperties, type ForwardedRef, forwardRef } from "react";
+import { useContextProps } from "react-aria-components";
 
-const classNames = clsx(className, GlobalButtonCssSelector, cssModule(styles, "hop-Button"), stylingProps.className);
-const mergedStyles: CSSProperties = { ...stylingProps.style, ...style };
+function IconList(props: IconListProps, ref: ForwardedRef<HTMLSpanElement>) {
+  [props, ref] = useContextProps(props, ref, IconListContext);
+
+  const { stylingProps, ...ownProps } = useStyledSystem(props);
+  const { children, style, className, slot, size, ...otherProps } = ownProps;
+
+  const classNames = clsx(className, GlobalIconListCssSelector, styles["hop-IconList"], stylingProps.className);
+  const mergedStyles: CSSProperties = { ...stylingProps.style, ...style };
+}
+
+const _IconList = slotFn("icon", forwardRef(IconList));
 ```
 
-A component with a default slot passes it in: `useContextProps({ ...props, slot: props.slot || DefaultIconListSlot }, ref, IconListContext)`.
+Components built on a React Aria render-prop `className` use `composeClassnameRenderProps` instead of
+`clsx` — 44 files do, including `Button`. Argument order varies between the two helpers and carries no
+meaning; what matters is that all four parts appear.
+
+`cssModule(styles, "hop-Name", ...modifiers)` resolves modifier classes. Some files pass the
+`Global<Name>CssSelector` constant in place of the literal, and a few index `styles[...]` directly.
+
+The spread order of `style` is **not** settled — 26 files put `stylingProps.style` first and 27 put it
+last. Match the file you are editing rather than changing it.
 
 ## Folder layout
 
-Each component group is a kebab-case directory under `src/`.
+Component groups are kebab-case directories under `src/`. `typography/` and `overlays/` nest one level
+deeper, as `<group>/<subgroup>/src/`.
 
-| Path                       | Holds                                                                        |
-| -------------------------- | ---------------------------------------------------------------------------- |
-| `<group>/src/`             | `Component.tsx`, `Component.module.css`, `ComponentContext.ts` in PascalCase |
-| `<group>/tests/vitest/`    | `*.test.tsx` and `*.ssr.test.tsx`                                            |
-| `<group>/tests/chromatic/` | `*.stories.tsx`                                                              |
-| `<group>/docs/`            | Per-component doc folders and `migration-notes*.md`                          |
-| `<group>/index.ts`         | Barrel re-export                                                             |
+| Path                       | Holds                                                                                                            |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `<group>/src/`             | PascalCase `Component.tsx`, `Component.module.css`, `ComponentContext.ts`, plus `index.ts` and camelCase helpers |
+| `<group>/tests/vitest/`    | `*.test.tsx` and `*.ssr.test.tsx` — every group has this                                                         |
+| `<group>/tests/chromatic/` | `*.stories.tsx` — 40 of 43 groups                                                                                |
+| `<group>/docs/`            | Documentation, plus `migration-notes*.md` where the component replaces an Orbiter one                            |
+| `<group>/index.ts`         | Barrel re-export                                                                                                 |
+
+Some groups also carry `utils/`, `hooks/` or `assets/` siblings.
 
 ## Accessibility checks
 
 The axe runner is local-only. Run `pnpm storybook-nolazy` in one terminal and `pnpm test-storybook`
-in another — the lazy-loading variant is incompatible with the runner.
+in another — the lazy-loading variant is incompatible with the runner. See `contributing/components.md`.

--- a/packages/icons/AGENTS.md
+++ b/packages/icons/AGENTS.md
@@ -42,3 +42,13 @@ one word and comes back title-cased:
 | `CSV.svg`         | `csv-16.svg`          | `CsvIcon`         |
 
 Reach for the exported name — `AiIcon`, not `AIIcon`.
+
+## The accessibility invariant
+
+`Icon.tsx` sets `focusable="false"` unconditionally and `aria-hidden` unless an `aria-label` is
+supplied, so a decorative icon cannot be exposed to a screen reader by omission. Preserve that when
+touching `createIcon` / `createRichIcon` or the generator — it is a repo-wide guarantee, and losing it
+is silent. See [ADR 0009](../../docs/adr/0009-accessibility-baseline.md).
+
+The generated rich-icon components hardcode hex fallbacks — `fill="var(--hop-RichIcon-placeholder-background, #E5DED6)"`
+across 49 files. They are generator output and intentional, not violations of the tokens-only rule.

--- a/packages/icons/AGENTS.md
+++ b/packages/icons/AGENTS.md
@@ -2,32 +2,43 @@
 
 ## Hard Rules
 
-| Rule                                                                                             | Violation                                                     |
-| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
-| Author an icon as PascalCase SVG under `packages/svg-icons/src/icons/<size>px/`, then regenerate | Hand-editing a file under `src/generated-icon-components/`    |
-| Add the SVG at every size its family defines                                                     | Adding `Add.svg` to `16px/` only                              |
-| Regenerate with `pnpm generate-icons` from the repo root                                         | Running one package's `generate-icons` script on its own      |
-| Build icon components through `createIcon` / `createRichIcon`                                    | Hand-writing the per-size wrapper boilerplate in an icon file |
+| Rule                                                                                     | Violation                                                  |
+| ---------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Author an icon as a PascalCase SVG under `packages/svg-icons/src/<family>/<size>px/`     | Hand-editing a file under `src/generated-icon-components/` |
+| Add the SVG at every size its family defines                                             | Adding `Add.svg` to `16px/` only                           |
+| Add a matching `packages/svg-icons/src/<family>/metadata/<Name>.json`                    | 219 SVGs and 218 metadata entries                          |
+| Regenerate with `pnpm generate-icons` from the repo root, then commit the generated diff | Leaving regenerated components uncommitted                 |
+| Build components through `createIcon` / `createRichIcon`                                 | Hand-writing the per-size wrapper boilerplate              |
 
-`src/generated-icon-components/` and `src/generated-rich-icon-components/` are build output. `oxfmt`
-ignores both, and a hand edit is lost on the next generation.
+Generated output is **committed**, not disposable: 221 files under `src/generated-icon-components/` and
+49 under `src/generated-rich-icon-components/` are tracked. `oxfmt` ignores both, so a hand edit
+survives formatting but is lost on the next generation.
 
-## Sizes per family
-
-The generator throws on a size directory outside its family's set.
+## Families
 
 | Family     | Authored in                          | Sizes      |
 | ---------- | ------------------------------------ | ---------- |
 | Icons      | `packages/svg-icons/src/icons/`      | 16, 24, 32 |
 | Rich icons | `packages/svg-icons/src/rich-icons/` | 24, 32, 40 |
 
-## Pipeline
+The optimizer throws when it finds an SVG in a size directory outside its family's set. A _missing_
+size is not caught — `createIcon` takes its three sources positionally, so the generator emits a
+reference to an undefined identifier and the broken TSX only surfaces at typecheck:
 
-`pnpm generate-icons` optimizes the authored SVGs, renaming `AddCalendar.svg` to
-`add-calendar-16.svg`, then generates the React components.
+```tsx
+export const AiIcon = createIcon(AiIcon16, AiIcon24, AiIcon32, "AiIcon");
+```
 
-| Path                                            | Holds                      |
-| ----------------------------------------------- | -------------------------- |
-| `packages/svg-icons/src/icons/<size>px/`        | Authored SVGs, PascalCase  |
-| `packages/svg-icons/src/optimized-icons/`       | Optimizer output           |
-| `packages/icons/src/generated-icon-components/` | Generated React components |
+## Naming through the pipeline
+
+`pnpm generate-icons` optimizes the authored SVGs to kebab-case with a size suffix, then generates the
+components. The kebab step splits only on a lowercase-to-uppercase boundary, so an all-caps name stays
+one word and comes back title-cased:
+
+| Authored          | Optimized             | Exported          |
+| ----------------- | --------------------- | ----------------- |
+| `AddCalendar.svg` | `add-calendar-16.svg` | `AddCalendarIcon` |
+| `AI.svg`          | `ai-16.svg`           | `AiIcon`          |
+| `CSV.svg`         | `csv-16.svg`          | `CsvIcon`         |
+
+Reach for the exported name — `AiIcon`, not `AIIcon`.

--- a/packages/icons/AGENTS.md
+++ b/packages/icons/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md - icons
+
+## Hard Rules
+
+| Rule                                                                                             | Violation                                                     |
+| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| Author an icon as PascalCase SVG under `packages/svg-icons/src/icons/<size>px/`, then regenerate | Hand-editing a file under `src/generated-icon-components/`    |
+| Add the SVG at every size its family defines                                                     | Adding `Add.svg` to `16px/` only                              |
+| Regenerate with `pnpm generate-icons` from the repo root                                         | Running one package's `generate-icons` script on its own      |
+| Build icon components through `createIcon` / `createRichIcon`                                    | Hand-writing the per-size wrapper boilerplate in an icon file |
+
+`src/generated-icon-components/` and `src/generated-rich-icon-components/` are build output. `oxfmt`
+ignores both, and a hand edit is lost on the next generation.
+
+## Sizes per family
+
+The generator throws on a size directory outside its family's set.
+
+| Family     | Authored in                          | Sizes      |
+| ---------- | ------------------------------------ | ---------- |
+| Icons      | `packages/svg-icons/src/icons/`      | 16, 24, 32 |
+| Rich icons | `packages/svg-icons/src/rich-icons/` | 24, 32, 40 |
+
+## Pipeline
+
+`pnpm generate-icons` optimizes the authored SVGs, renaming `AddCalendar.svg` to
+`add-calendar-16.svg`, then generates the React components.
+
+| Path                                            | Holds                      |
+| ----------------------------------------------- | -------------------------- |
+| `packages/svg-icons/src/icons/<size>px/`        | Authored SVGs, PascalCase  |
+| `packages/svg-icons/src/optimized-icons/`       | Optimizer output           |
+| `packages/icons/src/generated-icon-components/` | Generated React components |

--- a/packages/tokens/AGENTS.md
+++ b/packages/tokens/AGENTS.md
@@ -2,24 +2,32 @@
 
 ## Hard Rules
 
-| Rule                                                                                          | Violation                                                  |
-| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| Apply a component or semantic token change to every brand that defines it                     | Editing `sharegate/button.tokens.json` and not `workleap/` |
-| Give each token a `$type` and a `$value`, per DTCG                                            | A bare `"border-radius": "4px"`                            |
-| Point a component token at a core or semantic token by reference                              | `"$value": "4px"` where `{shape.rounded-md}` exists        |
-| Run `pnpm build:tokens` after any token edit — consumers read the generated CSS, not the JSON | Editing a `*.tokens.json` and running only `pnpm test`     |
+| Rule                                                                      | Violation                                                                       |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Apply a component or semantic token change to every brand that defines it | Editing `components/sharegate/button.tokens.json` and not `workleap/`           |
+| Give each token a `$type` and a `$value`, per DTCG                        | A bare `"border-radius": "4px"`                                                 |
+| Point a component token at a core or semantic token by reference          | A raw `blur(10px)`, as three sharegate elevation tokens still do                |
+| Run `pnpm build:tokens && pnpm build:pkg` after any token edit            | Renaming a token and leaving `styledSystemToTokenMappings.ts` stale in the tree |
+
+The two brands are currently symmetrical — an identical 21 component files and 11 semantic files each,
+with matching leaf counts. Keep them that way; asymmetry is how a brand silently loses a token.
+
+`src/tokens/asset/fonts.tokens.json` is the one non-DTCG file. It uses bare `value` + `formats`
+because the `font-face` format consumes it directly. Leave it alone.
 
 ## Layout
 
-| Path                             | Holds                                                                  |
-| -------------------------------- | ---------------------------------------------------------------------- |
-| `src/tokens/core/`               | Raw brand-independent values                                           |
-| `src/tokens/semantic/<brand>/`   | Intent-named tokens (`neutral-text`, `space-inline-xs`)                |
-| `src/tokens/components/<brand>/` | Per-component tokens, keyed `comp-<component>`, one file per component |
-| `src/tokens/asset/`              | Asset references                                                       |
-| `src/style-dictionary/`          | The build that turns the JSON into CSS custom properties               |
+| Path                                 | Holds                                                                |
+| ------------------------------------ | -------------------------------------------------------------------- |
+| `src/tokens/core/`                   | Raw brand-independent values — 6 flat files                          |
+| `src/tokens/semantic/<brand>/light/` | Intent-named tokens (`neutral.text`, `space.inline`) — 8 files       |
+| `src/tokens/semantic/<brand>/dark/`  | Colour overrides only — 3 files; everything else inherits from light |
+| `src/tokens/components/<brand>/`     | One file per token _family_, root-keyed `comp-<family>`              |
+| `src/tokens/asset/`                  | `@font-face` CDN sources, built into `dist/fonts.css`                |
+| `src/style-dictionary/`              | The build                                                            |
 
-A component token file is keyed by `comp-<component>` and its leaves reference semantic tokens:
+A component file is keyed `comp-<family>`, and its filename is `<parent>[.<child>].tokens.json`, which
+does **not** always match the key — `mark.checkbox.tokens.json` keys `comp-checkbox`. Grep the key.
 
 ```json
 {
@@ -28,3 +36,15 @@ A component token file is keyed by `comp-<component>` and its leaves reference s
   }
 }
 ```
+
+## What the build emits
+
+Five destinations, only one of them committed:
+
+| Output                                                                       | Committed                                            |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `dist/<brand>/tokens.css`, `dist/<brand>/dark/tokens.css`, `dist/fonts.css`  | No — gitignored                                      |
+| `packages/styled-system/src/tokens/generated/styledSystemToTokenMappings.ts` | **Yes** — a rename without a rebuild leaves it stale |
+| Docs and Storybook JSON                                                      | No                                                   |
+
+`styledSystemConstants.ts` sits in the same folder but is not produced by this build. Do not conflate them.

--- a/packages/tokens/AGENTS.md
+++ b/packages/tokens/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md - tokens
+
+## Hard Rules
+
+| Rule                                                                                          | Violation                                                  |
+| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Apply a component or semantic token change to every brand that defines it                     | Editing `sharegate/button.tokens.json` and not `workleap/` |
+| Give each token a `$type` and a `$value`, per DTCG                                            | A bare `"border-radius": "4px"`                            |
+| Point a component token at a core or semantic token by reference                              | `"$value": "4px"` where `{shape.rounded-md}` exists        |
+| Run `pnpm build:tokens` after any token edit — consumers read the generated CSS, not the JSON | Editing a `*.tokens.json` and running only `pnpm test`     |
+
+## Layout
+
+| Path                             | Holds                                                                  |
+| -------------------------------- | ---------------------------------------------------------------------- |
+| `src/tokens/core/`               | Raw brand-independent values                                           |
+| `src/tokens/semantic/<brand>/`   | Intent-named tokens (`neutral-text`, `space-inline-xs`)                |
+| `src/tokens/components/<brand>/` | Per-component tokens, keyed `comp-<component>`, one file per component |
+| `src/tokens/asset/`              | Asset references                                                       |
+| `src/style-dictionary/`          | The build that turns the JSON into CSS custom properties               |
+
+A component token file is keyed by `comp-<component>` and its leaves reference semantic tokens:
+
+```json
+{
+  "comp-button": {
+    "border-radius": { "$type": "borderRadius", "$value": "{shape.rounded-md}" }
+  }
+}
+```


### PR DESCRIPTION
## Summary

Supersedes #1015. That PR added seven component-architecture guidelines to `AGENTS.md`, but wrote them in the format `AGENTS.md` already used — an ex-Cursor rule shape stating each title three times (`## Title`, `Title:`, `Description:`) and ending in an orphaned `Path patterns:` line no tool reads. Replaying it would have tripled down on the defect this PR removes, so the guidelines are distributed by trigger instead.

The root `AGENTS.md` had grown into a flat 80-line file mixing commands, CSS rules and naming conventions. Nothing routed, so every rule cost context on every turn whether or not it applied. It is now a 106-line routing hub over four tiers:

| Tier           | Location                                          | Admits                                                         | Trigger                             |
| -------------- | ------------------------------------------------- | -------------------------------------------------------------- | ----------------------------------- |
| Root           | `AGENTS.md`                                       | Routing tables, hard rules, validation commands, workflow, git | Always loaded                       |
| Glob rules     | `.claude/rules/*.md`                              | Mechanical rules whose trigger is _fully_ a path glob          | `paths:` frontmatter, auto-attached |
| Semantic rules | `docs/agents/*.md`                                | Rules triggered by a concept no glob can express               | Trigger-routing table row           |
| Scoped         | `packages/<pkg>/AGENTS.md`, `apps/docs/AGENTS.md` | Structure and naming unique to one package                     | Path-routing table row              |

The admission test between the two rule tiers is whether a glob captures the whole trigger. "Editing a `.module.css` under components" does. "Changing a public API" does not.

`.claude/rules/` is Claude-Code-only, and its attachment is not documented for subagents — a routing spot-check confirmed a subagent receives no auto-attach. `AGENTS.md` therefore also lists those three files in a path table, which is what makes them reachable for Cursor, Copilot, Codex and subagents alike.

## Where #1015's guidelines went

| Guideline                                                                              | Landed in                               |
| -------------------------------------------------------------------------------------- | --------------------------------------- |
| Never lock consumers in; composition over config props; brand defaults; mobile sibling | `docs/agents/component-architecture.md` |
| Support running multiple versions in parallel                                          | `docs/agents/versioning.md`             |
| Components must be SSR-safe                                                            | `.claude/rules/component-tsx.md`        |
| Keep runtime dependencies minimal                                                      | `.claude/rules/package-json.md`         |

Those guidelines were proposal language, so `component-architecture.md` now separates confirmed rules from **goals for new API surface**, naming where the code diverges rather than implying compliance. Otherwise an agent would try to "fix" shipped public API: `Alert`'s three `on*ButtonClick` props and `TextField.onClear` are typed `() => void`, 18 `ReactNode` content props ship today, and 8 components expose no wrapper prop bag.

## Bugs fixed in the original docs

| Bug                                                        | Impact                                                                                                                                                                                 |
| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `CLAUDE.md` was a symlink whose target was `"AGENTS.md\n"` | The trailing newline made it dangle on macOS and Linux — every non-Windows contributor had no project instructions. Now a regular file holding `@AGENTS.md` (mode `120000` → `100644`) |
| `pnpm tsc --noEmit` was documented as the typecheck        | Root `tsconfig.json` excludes `packages` and `apps`, so it reported success while every component went unchecked                                                                       |
| No build command documented at all                         | `pnpm build:pkg` is required after install; it lived only in `CONTRIBUTING.md`                                                                                                         |
| Test-naming rule said camelCase                            | The repo is 149 PascalCase to 11 camelCase. The real rule is "matches the unit under test"                                                                                             |
| Component tokens documented as one layer                   | There are three, and the boundary is the token _family_, not the component                                                                                                             |
| Skills table claimed to list the repo's skills             | Listed 3 of 10, under names that cannot be typed                                                                                                                                       |
| `AGENTS.md` never linked `CONTRIBUTING.md`                 | An agent reading only `AGENTS.md` never learned packages must be built first                                                                                                           |
| Changesets went unmentioned everywhere                     | Every change to the 5 published packages needs one                                                                                                                                     |
| `claude.yml` marked a branch-naming rule `**CRITICAL**`    | No such rule existed anywhere in the repo                                                                                                                                              |

`## Code style` is deleted rather than moved: `oxfmt` and `oxlint` already enforce quotes, casing and indentation, and a `PostToolUse` hook applies them after every write.

## Second commit: every rule validated against the source

Six agents validated all 11 files rule by rule. About a third of the rules were wrong. Each finding was verified directly before the fix — full detail is in the commit message.

**Commands that could not work as written.** `turbo` is not on `PATH`, so all three `turbo run …` rows failed with "command not found". Turbo filters on package `name`, so the `--filter=<package>` placeholder was a trap — `--filter=components` matches zero packages. Worse, two rows were **silent false greens**: `turbo run typecheck --filter=docs` resolves a task whose command is `<NONEXISTENT>` and exits 0, because `apps/docs` has no typecheck script; the same holds for stylelint on the two packages lacking it. Both are now called out in the doc.

**Rules the codebase contradicts.** Two were mine and simply wrong:

- _"Rebuild after changing a public API"_ — the `hopper-source` export condition resolves packages from source, so typecheck, tests, Storybook and the docs site see TS changes with no rebuild.
- _"Declare devDependencies per package, pnpm does not hoist"_ — backwards. No package declares `stylelint` or `vitest`; they are root-only by design, and the rule contradicted root `AGENTS.md`.

Also corrected: `packages/components/src/html-elements/` holds only doc previews (the native wrappers are in `packages/styled-system/src/html-wrappers/html.ts`, where the `Html` prefix convention makes a native select `HtmlSelect` after all); `Global<Name>CssSelector` is not universal (14 of 116 components ship none); and the `style` spread order is genuinely unsettled at 26 files versus 27, so it is no longer stated as a rule.

**Fabricated examples removed.** An agent calibrates on the violation column, so a fake example teaches it to look for the wrong shape of mistake. `var(--hop-comp-tooltip-color)` in `AvatarGroup.module.css` was inherited from the old `AGENTS.md` and never existed. `padding: 8px` cannot be written — `px` is outside stylelint's `unit-allowed-list`. `[HeadingContext, { fontWeight: … }]`, `DefaultIconListSlot`, `ValidationService.ts`, `ButtonProps.ts`, `breakpoints.ts`, `formatDate.ts` and `useHover.ts` do not exist. Every naming example in `typescript.md` is now a verified real file.

**One validator was wrong and it mattered.** An agent reported that `.claude/rules/` is not a Claude Code feature and that `paths:` is a Cursor convention — which would have meant deleting that whole tier. Its evidence was that nothing in the repo references the directory, but the loader is the runtime, not the repo, so grepping for wiring a built-in does not need cannot disprove it. Verified against the official docs before acting; the tier stands.

## Verification

- `CLAUDE.md` committed as mode `100644`
- `AGENTS.md` 106 lines, 49 table rows, 14 imperative markers, `## Build` heading plus `- Build:`/`- Test:` bullets, no decorative dividers
- Every path and link across all 11 files resolves — this check caught a real bug in the draft (`generated-icon-components/` should have been `src/generated-icon-components/`)
- All 3 rule globs match tracked files (90 / 116 / 5), so none is dead
- `pnpm format:check` passes
- Routing spot-check: an agent given only "change the Button's disabled text color", told nothing about the docs, reached `component-css.md`, both scoped `AGENTS.md` files and `versioning.md`, and correctly skipped the four irrelevant files

## Reviewer notes

- **Branch and PR naming is the one claim derived from history rather than code.** Branches are `<TICKET>-<kebab-description>` (50% of recent PRs). For titles I documented `<TICKET>: <Title>` as primary because it is 46% against 32% for the bracket form — if the bracket form is the intended going-forward standard, say so and I will flip it.
- `oxfmt` ignores `.claude/**`, so table padding in `.claude/rules/*` is hand-maintained while `AGENTS.md` and `docs/agents/*` are auto-formatted.
- `contributing/*.md` is untouched and stays the human contributor guide; `AGENTS.md` now links to it so the overlap has a declared direction. Two stale paths in it surfaced during validation (`packages/i18n/src/intl` and the duplicated clause at `CONTRIBUTING.md:44`) but are out of scope here.

## Follow-ups (not in this PR)

- **Four skill files still route rules to "root `CLAUDE.md`"**, now a one-line import — `learn-from-feedback/SKILL.md` (49, 59, 83, 87), `_port-component/SKILL.md` (135, 136) and its two reference docs. Validation traced three of the fabricated examples above to `_port-component/references/component-anatomy.md:99,179-183`, so they will keep propagating until that file is corrected.
- `.github/workflows/claude.yml:56` grants `Bash(pnpm tsc:*)`, propagating the command this PR deletes.
- **Real bug found in passing:** `packages/components/src/date-picker/src/DateInput.module.css:18` reads `var(--hop-Input-padding-inline-end)`, which is declared nowhere; line 6 declares `--hop-DateInput-padding-inline-end` and never uses it. `padding-inline-end` currently resolves to nothing.
- Two more surfaced and are worth filing: `SegmentedControlItem.tsx:63` reads `window.matchMedia` during render, and `modal/tests/vitest/CustomModal.srr.test.tsx` is misspelled so it matches no `*.ssr.test.tsx` glob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
