### PR TITLE
fix: use limeburst for the ShareGate Upsell Button background gradient

### DIFF
--- a/.changeset/silver-moons-smile.md
+++ b/.changeset/silver-moons-smile.md
@@ -1,0 +1,7 @@
+---
+"@hopper-ui/tokens": patch
+"@hopper-ui/styled-system": patch
+"@hopper-ui/components": patch
+---
+
+Update the ShareGate Upsell Button background gradient to end on `limeburst.100` instead of `persimmon.300`.

--- a/packages/tokens/src/tokens/components/sharegate/button.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/button.tokens.json
@@ -381,14 +381,14 @@
                 "$type": "gradient",
                 "$value": [
                     { "color": "{limeburst.50}", "position": 0 },
-                    { "color": "{persimmon.300}", "position": 1.5156 }
+                    { "color": "{limeburst.100}", "position": 1.5156 }
                 ]
             },
             "background-loading": {
                 "$type": "gradient",
                 "$value": [
                     { "color": "{limeburst.50}", "position": 0 },
-                    { "color": "{persimmon.300}", "position": 1.5156 }
+                    { "color": "{limeburst.100}", "position": 1.5156 }
                 ]
             },
             "color-loading": {


### PR DESCRIPTION
## What

Replaces `persimmon.300` with `limeburst.100` as the end stop of the ShareGate Upsell Button background gradient, in both the default and loading states.

The gradient now runs `limeburst.50` (#ccff42) → `limeburst.100` (#a3df00).

## Scope

ShareGate only — `packages/tokens/src/tokens/components/sharegate/button.tokens.json`. The Workleap Upsell Button is unchanged.

## Generated output

```css
--hop-comp-button-upsell-background: linear-gradient(var(--hop-limeburst-50), var(--hop-limeburst-100) 151%);
--hop-comp-button-upsell-background-loading: linear-gradient(var(--hop-limeburst-50), var(--hop-limeburst-100) 151%);
```

## Note for review

The hover background (`upsell.surface-weak-hover`) also resolves to `limeburst.100`, so hover now lands on the same colour the default gradient ends on. Worth confirming in Chromatic that the hover state still reads as distinct — if not, a follow-up could move hover to `limeburst.200`.

## Validation

- `pnpm build:pkg` — passing
- `pnpm test` — 665 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)